### PR TITLE
Publish 1.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.9.2-SNAPSHOT - in development
+## 1.9.2 - pre-2.0 Maven Central release candidate
+
+`1.9.2` adds the first context-sensitive zero-width assertions to the
+published `1.9.x` line. It keeps the same pre-2.0 positioning as `1.9.1`, but
+now supports line anchors and ASCII word boundaries.
 
 ### Highlights
 
@@ -24,10 +28,11 @@
   `\b`/`\B`: same generated data, correctness pass, identical match counts,
   scanning ratios 0.911 on 1MB and 1.018 on 10MB.
 
-### Still required before release
+### Deliberate limitations and future work
 
-- Decide and document pure zero-width match semantics, for example `^$`.
-- Continue the broader #267 work for input anchors and flag-mode behavior.
+- Pure zero-width match reporting, for example `^$`, is still outside the
+  public support contract because callbacks currently report consumed spans.
+- The broader #267 work continues for input anchors and flag-mode behavior.
 
 ## 1.9.1 - pre-2.0 Maven Central release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 published `1.9.x` line. It keeps the same pre-2.0 positioning as `1.9.1`, but
 now supports line anchors and ASCII word boundaries.
 
+Published to Maven Central on 2026-07-08 as `no.rmz:rmatch:1.9.2`, with the
+Git tag `rmatch-1.9.2` pointing at release commit `48151212`.
+
 ### Highlights
 
 - Added the first zero-width assertion machinery for line anchors `^` and `$`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.9.3-SNAPSHOT - in development
+
 ## 1.9.2 - pre-2.0 Maven Central release candidate
 
 `1.9.2` adds the first context-sensitive zero-width assertions to the

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add rmatch to an existing Maven project:
 <dependency>
   <groupId>no.rmz</groupId>
   <artifactId>rmatch</artifactId>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ For Gradle:
 
 ```kotlin
 dependencies {
-    implementation("no.rmz:rmatch:1.9.1")
+    implementation("no.rmz:rmatch:1.9.2")
 }
 ```
 
@@ -121,7 +121,7 @@ For a complete scratch project, use this full `pom.xml`:
     <dependency>
       <groupId>no.rmz</groupId>
       <artifactId>rmatch</artifactId>
-      <version>1.9.1</version>
+      <version>1.9.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -70,6 +70,9 @@ the rest of the release work here as it becomes explicit.
 - [x] Create and push the `rmatch-1.9.2` tag. Result on 2026-07-08:
   annotated tag `rmatch-1.9.2` points at uploaded release commit `48151212`
   and was pushed to `origin`.
+- [x] Bump repository back to the next development snapshot. Result on
+  2026-07-08: POMs moved from final `1.9.2` release versions to
+  `1.9.3-SNAPSHOT`; README examples remain on the published `1.9.2` version.
 
 ## Identity and Access
 

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -19,6 +19,38 @@ the rest of the release work here as it becomes explicit.
   continue mainline development on `2.0-SNAPSHOT`; use the `1.9.x` release
   branch only for release-candidate stabilization.
 
+## 1.9.2 Release Run
+
+- [x] Sync release worktree from current `origin/main`. Result on 2026-07-08:
+  release branch `u/la3lma/codex/release-1.9.2` starts at `d9fe0eca`, the
+  merge of PR #277 with word-boundary assertions.
+- [x] Set release POM versions and README snippets to `1.9.2`.
+- [x] Convert `1.9.2` changelog notes from snapshot wording to release-candidate
+  wording, with pure zero-width reporting and flag-mode behavior documented as
+  future work rather than release blockers.
+- [x] Run full release preflight. Result on 2026-07-08:
+  `make release-central-preflight` succeeded.
+- [x] Run Central profile check without signing/uploading. Result on
+  2026-07-08: `make release-central-profile-check` succeeded.
+- [x] Run signed Central release-profile verify. Result on 2026-07-08:
+  `./mvnw -B -pl rmatch -am -Pcentral-release -DskipTests
+  -Dspotbugs.skip=true -Dgpg.keyname=55D9C01E75B1E582 verify` succeeded and
+  signed the parent POM plus rmatch POM, main JAR, source JAR, and Javadoc JAR.
+- [x] Verify `1.9.2` generated `.asc` signatures locally. Result on
+  2026-07-08: `gpg --verify` reported good signatures for all generated
+  release artifacts using key `9017955845408C9B4422B5DE55D9C01E75B1E582`.
+- [x] Inspect `1.9.2` JAR manifest, embedded POM properties, and Java baseline.
+  Result on 2026-07-08: manifest has `Java-Version: 21`, no application
+  `Main-Class`, embedded properties report `no.rmz:rmatch:1.9.2`, and
+  `javap` reports classfile major version 65.
+- [x] Verify `1.9.2` compile dependency tree. Result on 2026-07-08:
+  `no.rmz:rmatch` has only `org.ahocorasick:ahocorasick:0.6.3` in compile
+  scope.
+- [x] Run a downstream consumer smoke test after local install. Result on
+  2026-07-08: `/tmp/rmatch-192-consumer-smoke.XBPoXD`, command
+  `mvn -q clean verify exec:java -Dexec.mainClass=Example`, printed
+  `log-level match: WARN` and `user token match: user:alice`.
+
 ## Identity and Access
 
 - [x] Create a current GPG release-signing key.
@@ -179,10 +211,15 @@ the rest of the release work here as it becomes explicit.
   0 failures, 0 errors, 2 skipped; Spotless and SpotBugs passed in both
   modules. `javap` on `no.rmz.rmatch.impls.MatcherImpl` reported classfile
   major version 65.
-- [ ] Before release, audit source, tests, benchmark harnesses, and build/release
+- [x] Before release, audit source, tests, benchmark harnesses, and build/release
   scripts for deprecated method/API usage. Remove deprecated calls where
   practical; document and track any unavoidable remaining usage. Track this
-  under [issue #272](https://github.com/la3lma/rmatch/issues/272).
+  under [issue #272](https://github.com/la3lma/rmatch/issues/272). Result for
+  `1.9.2` on 2026-07-08: source/test/build grep found the public deprecated
+  `Buffer.getCurrentRestString()` method and its test implementation delegate.
+  This is deliberate compatibility surface and should not be removed during the
+  `1.9.2` release cut; keep the cleanup tracked under
+  [issue #272](https://github.com/la3lma/rmatch/issues/272).
 - [ ] Before 2.0, audit for unused methods, classes, and interfaces that are not
   part of the intended external API. Remove unused accidental/internal surface
   where safe; document any unused public surface that is intentionally retained.

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -50,6 +50,26 @@ the rest of the release work here as it becomes explicit.
   2026-07-08: `/tmp/rmatch-192-consumer-smoke.XBPoXD`, command
   `mvn -q clean verify exec:java -Dexec.mainClass=Example`, printed
   `log-level match: WARN` and `user token match: user:alice`.
+- [x] Upload the `1.9.2` release commit to Central Portal. Result on
+  2026-07-08: release commit `48151212` deployed as Central deployment
+  `ea3d5702-e26e-4376-974c-6e094298aac8`; validation succeeded.
+- [x] Publish the validated `1.9.2` Central deployment. Result on 2026-07-08:
+  the deployment moved from `VALIDATED` to `PUBLISHING` via the Central
+  Publisher API and then reached `PUBLISHED`.
+- [x] Confirm `1.9.2` artifact availability from Maven Central. Result on
+  2026-07-08: direct checks for
+  `https://repo.maven.apache.org/maven2/no/rmz/rmatch/1.9.2/rmatch-1.9.2.pom`
+  and the corresponding `-javadoc.jar` returned HTTP 200.
+- [x] Run a clean-repository consumer smoke test against Maven Central
+  `1.9.2`. Result on 2026-07-08:
+  `/tmp/rmatch-192-central-consumer-smoke.Hq0dTH` with empty Maven repository
+  `/tmp/rmatch-192-central-m2.XCCLKb`, command
+  `mvn -Dmaven.repo.local=/tmp/rmatch-192-central-m2.XCCLKb -q clean verify
+  exec:java -Dexec.mainClass=Example`, printed `log-level match: WARN` and
+  `user token match: user:alice`.
+- [x] Create and push the `rmatch-1.9.2` tag. Result on 2026-07-08:
+  annotated tag `rmatch-1.9.2` points at uploaded release commit `48151212`
+  and was pushed to `origin`.
 
 ## Identity and Access
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-parent</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.2</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-parent</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.3-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rmatch-tester/pom.xml
+++ b/rmatch-tester/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.2</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-tester</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.2</version>
     <packaging>jar</packaging>
 
     <name>rmatch-tester</name>

--- a/rmatch-tester/pom.xml
+++ b/rmatch-tester/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-tester</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>rmatch-tester</name>

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.2</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.2</version>
     <packaging>jar</packaging>
 
     <name>rmatch</name>

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>rmatch</name>


### PR DESCRIPTION
## Summary

Publishes the 1.9.2 release line and returns development to `1.9.3-SNAPSHOT`.

The release tag `rmatch-1.9.2` points at `48151212`, the exact commit uploaded to Maven Central. The later commits on this branch only record publication evidence and bump the repo back to the next snapshot.

## Release evidence

- Central deployment: `ea3d5702-e26e-4376-974c-6e094298aac8`
- Deployment reached `PUBLISHED`
- Maven Central POM: `https://repo.maven.apache.org/maven2/no/rmz/rmatch/1.9.2/rmatch-1.9.2.pom` returned HTTP 200
- Maven Central Javadoc JAR returned HTTP 200
- Clean Central-only consumer smoke passed with an empty local Maven repository
- Tag pushed: `rmatch-1.9.2`

## Validation

- `make release-central-preflight`
- `make release-central-profile-check`
- `./mvnw -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.keyname=55D9C01E75B1E582 verify`
- Local signature verification for generated `.asc` files
- `./mvnw -pl rmatch dependency:tree -Dscope=compile`
- Local downstream consumer smoke against installed `1.9.2`
- Central downstream consumer smoke against published `1.9.2`
- Post-release `./mvnw -q -B -pl rmatch -am -DskipTests -Dspotbugs.skip=true package`
