### PR TITLE
Remove deprecated buffer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.9.3-SNAPSHOT - in development
 
+### Release hygiene
+
+- Removed the deprecated `Buffer.getCurrentRestString()` method from the public
+  buffer contract. Internal users now either request explicit substrings or
+  collect remaining text by advancing a cloned cursor.
+
 ## 1.9.2 - pre-2.0 Maven Central release candidate
 
 `1.9.2` adds the first context-sensitive zero-width assertions to the

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -238,11 +238,10 @@ the rest of the release work here as it becomes explicit.
   scripts for deprecated method/API usage. Remove deprecated calls where
   practical; document and track any unavoidable remaining usage. Track this
   under [issue #272](https://github.com/la3lma/rmatch/issues/272). Result for
-  `1.9.2` on 2026-07-08: source/test/build grep found the public deprecated
-  `Buffer.getCurrentRestString()` method and its test implementation delegate.
-  This is deliberate compatibility surface and should not be removed during the
-  `1.9.2` release cut; keep the cleanup tracked under
-  [issue #272](https://github.com/la3lma/rmatch/issues/272).
+  `1.9.3-SNAPSHOT`: the deprecated `Buffer.getCurrentRestString()` API was
+  removed from the public buffer contract, internal call sites were replaced
+  with explicit cursor/substring logic, and the warning-visible Maven test pass
+  no longer reports deprecation warnings.
 - [ ] Before 2.0, audit for unused methods, classes, and interfaces that are not
   part of the intended external API. Remove unused accidental/internal surface
   where safe; document any unused public surface that is intentionally retained.

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/JavaRegexpMatcher.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/JavaRegexpMatcher.java
@@ -101,12 +101,20 @@ public class JavaRegexpMatcher implements Matcher {
 
   @Override
   public void match(final Buffer b) {
-    makeMatchers(b, b.getCurrentRestString());
+    makeMatchers(b, collectRemainingText(b.clone()));
     try {
       es.invokeAll(matchers);
     } catch (InterruptedException ex) {
       throw new RuntimeException(ex);
     }
+  }
+
+  private static String collectRemainingText(final Buffer cursor) {
+    final StringBuilder text = new StringBuilder();
+    while (cursor.hasNext()) {
+      text.append(cursor.getNext());
+    }
+    return text.toString();
   }
 
   private Set<String> getSetForAction(final Action action) {

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/StringSourceBuffer.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/StringSourceBuffer.java
@@ -132,13 +132,6 @@ public final class StringSourceBuffer implements Buffer, Cloneable {
   }
 
   @Override
-  public String getCurrentRestString() {
-    synchronized (monitor) {
-      return getCurrentRestString(getCurrentPos() + 1);
-    }
-  }
-
-  @Override
   public String toString() {
     synchronized (monitor) {
       return "[RegexStringBuffer currentPos = " + currentPos + ". str = " + str + "]";

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/WutheringHeightsBuffer.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/WutheringHeightsBuffer.java
@@ -77,11 +77,6 @@ public final class WutheringHeightsBuffer implements Buffer, Cloneable {
     return sb.getLength();
   }
 
-  @Override
-  public String getCurrentRestString() {
-    return sb.getCurrentRestString();
-  }
-
   /**
    * Get the substring from position 'pos' going on to the end of the text.
    *

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/BloomFilterMatchEngine.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/BloomFilterMatchEngine.java
@@ -407,11 +407,6 @@ public final class BloomFilterMatchEngine implements MatchEngine {
     }
 
     @Override
-    public String getCurrentRestString() {
-      return pos >= 0 ? text.substring(Math.min(pos + 1, text.length())) : text;
-    }
-
-    @Override
     public String getString(final int start, final int stop) {
       return text.substring(Math.max(0, start), Math.min(text.length(), stop));
     }

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/FastPathMatchEngine.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/FastPathMatchEngine.java
@@ -347,10 +347,19 @@ public final class FastPathMatchEngine implements MatchEngine {
   /** Collect buffer text for prefilter scanning without consuming the original buffer. */
   private String collectBufferText(final Buffer b) {
     try {
-      return b.clone().getCurrentRestString();
+      return collectRemainingText(b.clone());
     } catch (RuntimeException ex) {
       return null;
     }
+  }
+
+  /** Collect the remaining text by advancing a cloned cursor. */
+  private static String collectRemainingText(final Buffer cursor) {
+    final StringBuilder text = new StringBuilder();
+    while (cursor.hasNext()) {
+      text.append(cursor.getNext());
+    }
+    return text.toString();
   }
 
   /** Run prefilter scan to identify candidate positions. */

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MatchEngineImpl.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MatchEngineImpl.java
@@ -326,10 +326,19 @@ public final class MatchEngineImpl implements MatchEngine {
   /** Collects the full text from the buffer for prefilter scanning without consuming it. */
   private String collectBufferText(final Buffer b) {
     try {
-      return b.clone().getCurrentRestString();
+      return collectRemainingText(b.clone());
     } catch (RuntimeException ex) {
       return null;
     }
+  }
+
+  /** Collect the remaining text by advancing a cloned cursor. */
+  private static String collectRemainingText(final Buffer cursor) {
+    final StringBuilder text = new StringBuilder();
+    while (cursor.hasNext()) {
+      text.append(cursor.getNext());
+    }
+    return text.toString();
   }
 
   /**

--- a/rmatch/src/main/java/no/rmz/rmatch/interfaces/Buffer.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/interfaces/Buffer.java
@@ -27,17 +27,6 @@ package no.rmz.rmatch.interfaces;
 public interface Buffer extends Comparable<Buffer> {
 
   /**
-   * Return the unconsumed suffix after the current position.
-   *
-   * <p>This method exists for older diagnostics and tests. New application code should normally use
-   * {@link #getString(int, int)} with explicit offsets.
-   *
-   * @return text after the current cursor position
-   */
-  @Deprecated
-  String getCurrentRestString();
-
-  /**
    * Return a substring from the underlying input.
    *
    * <p>The {@code stop} argument is exclusive, matching {@link String#substring(int, int)}. Match

--- a/rmatch/src/main/java/no/rmz/rmatch/utils/RegexStringBuffer.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/utils/RegexStringBuffer.java
@@ -165,18 +165,6 @@ public final class RegexStringBuffer implements LookaheadBuffer, Cloneable {
     }
   }
 
-  /**
-   * Return the unconsumed suffix after the current cursor position.
-   *
-   * @return remaining text after the current cursor
-   */
-  @Override
-  public String getCurrentRestString() {
-    synchronized (monitor) {
-      return getCurrentRestString(getCurrentPos() + 1);
-    }
-  }
-
   @Override
   public String toString() {
     synchronized (monitor) {

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/LookaheadBufferImpl.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/LookaheadBufferImpl.java
@@ -30,14 +30,6 @@ public class LookaheadBufferImpl implements LookaheadBuffer, Cloneable {
   }
 
   @Override
-  @Deprecated
-  public String getCurrentRestString() {
-    synchronized (lock) {
-      return buffer.getCurrentRestString();
-    }
-  }
-
-  @Override
   public String getString(int start, int stop) {
     synchronized (lock) {
       return buffer.getString(start, stop);

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/LookaheadStringBufferTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/LookaheadStringBufferTest.java
@@ -42,15 +42,13 @@ public final class LookaheadStringBufferTest {
   /** Test that the length we get is the real one. */
   @Test
   public void testLength() {
-    //noinspection deprecation
-    assertEquals(lsb.getCurrentRestString().length(), staticString.length());
+    assertEquals(lsb.getString(0, staticString.length()).length(), staticString.length());
   }
 
   /** Test that the string that is stored is the right one. */
   @Test
   public void testEquality() {
-    //noinspection deprecation
-    assertEquals(lsb.getCurrentRestString(), staticString);
+    assertEquals(lsb.getString(0, staticString.length()), staticString);
   }
 
   /** Test that the length we get is the real one. */

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/MatcherImplPrefilterFallbackTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/MatcherImplPrefilterFallbackTest.java
@@ -88,11 +88,6 @@ public final class MatcherImplPrefilterFallbackTest {
     }
 
     @Override
-    public String getCurrentRestString() {
-      return text.substring(Math.min(currentPos + 1, text.length()));
-    }
-
-    @Override
     public String getString(final int start, final int stop) {
       return text.substring(Math.max(0, start), Math.min(stop, text.length()));
     }

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/StringBufferTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/StringBufferTest.java
@@ -42,14 +42,12 @@ public final class StringBufferTest {
   /** Test that the length we get is the real one. */
   @Test
   public void testLength() {
-    //noinspection deprecation
-    assertEquals(sb.getCurrentRestString().length(), staticString.length());
+    assertEquals(sb.getString(0, staticString.length()).length(), staticString.length());
   }
 
   /** Test that the string that is stored is the right one. */
   @Test
   public void testEquality() {
-    //noinspection deprecation
-    assertEquals(sb.getCurrentRestString(), staticString);
+    assertEquals(sb.getString(0, staticString.length()), staticString);
   }
 }

--- a/rmatch/src/test/java/no/rmz/rmatch/semantics/LineAnchorSemanticsTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/semantics/LineAnchorSemanticsTest.java
@@ -132,11 +132,6 @@ public class LineAnchorSemanticsTest {
     }
 
     @Override
-    public String getCurrentRestString() {
-      return text.substring(Math.min(currentPos + 1, text.length()));
-    }
-
-    @Override
     public String getString(final int start, final int stop) {
       return text.substring(start, stop);
     }

--- a/rmatch/src/test/java/no/rmz/rmatch/semantics/WordBoundarySemanticsTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/semantics/WordBoundarySemanticsTest.java
@@ -122,11 +122,6 @@ public class WordBoundarySemanticsTest {
     }
 
     @Override
-    public String getCurrentRestString() {
-      return text.substring(Math.min(currentPos + 1, text.length()));
-    }
-
-    @Override
     public String getString(final int start, final int stop) {
       return text.substring(start, stop);
     }


### PR DESCRIPTION
## Summary

This starts the `1.9.3-SNAPSHOT` cleanup lane for #272 by removing the deprecated `Buffer.getCurrentRestString()` method from the public `Buffer` contract.

Internal uses now either use explicit `getString(start, stop)` calls or collect remaining text by advancing a cloned buffer cursor. Test-only and benchmark-helper buffer implementations were updated accordingly.

## Validation

- `rg -n "@Deprecated|noinspection deprecation|\\bdeprecated\\b|\\bDeprecated\\b|deprecation|getCurrentRestString\\(\\)" -S .` now only finds the release checklist note.
- `./mvnw -B -pl rmatch -am test -Dspotbugs.skip=true` passed: 333 tests, 0 failures, 0 errors, 3 skipped.
- `./mvnw -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.keyname=55D9C01E75B1E582 verify` passed, including javadoc/source/signing packaging.
- `./mvnw -B -pl rmatch-tester -am package -DskipTests -Dspotbugs.skip=true` passed.

## Note

The full `rmatch-tester` test run still fails in `SequenceLoaderTest.testWutheringHeightsCorpusWithSomeRegexps` on an existing benchmark memory threshold (`maxNoOfMbsUsed=2028`). Compilation and packaging of the tester module are clean, so I have not changed benchmark thresholds in this deprecated-API cleanup PR.

Closes #272.
