### PR TITLE
Document JPMS Aho-Corasick boundary options

### DIFF
--- a/docs/design/jpms-aho-corasick-boundary.md
+++ b/docs/design/jpms-aho-corasick-boundary.md
@@ -1,0 +1,141 @@
+# JPMS and Aho-Corasick Dependency Boundary
+
+Issue: <https://github.com/la3lma/rmatch/issues/282>
+
+## Summary
+
+`rmatch` currently has an explicit JPMS descriptor:
+
+```java
+module no.rmz.rmatch {
+  requires java.logging;
+  requires java.management;
+  requires ahocorasick;
+}
+```
+
+The `ahocorasick` module name is derived from
+`org.ahocorasick:ahocorasick:0.6.3`, which has no `module-info.class` and no
+`Automatic-Module-Name` manifest entry. `javac` therefore treats it as a
+filename-derived automatic module and emits this release warning:
+
+```text
+Required filename-based automodules detected: [ahocorasick-0.6.3.jar].
+Please don't publish this project to a public artifact repository!
+```
+
+This is not a runtime failure and did not block `1.9.3`, but it means we should
+not call the JPMS story fully clean before `2.0.0`.
+
+## Evidence
+
+Baseline command on 2026-07-08:
+
+```bash
+./mvnw -B -pl rmatch -am -Pcentral-release \
+  -DskipTests -Dspotbugs.skip=true -Dgpg.skip=true clean verify
+```
+
+Result:
+
+- Build succeeds.
+- `javac` emits the filename-based automatic-module warning.
+- `javac` also reports `module-info.java:[4,12] requires directive for an
+  automatic module`.
+
+Dependency inspection:
+
+```bash
+jar --describe-module \
+  --file ~/.m2/repository/org/ahocorasick/ahocorasick/0.6.3/ahocorasick-0.6.3.jar
+```
+
+Result:
+
+```text
+No module descriptor found. Derived automatic module.
+
+ahocorasick@0.6.3 automatic
+```
+
+Maven Central reports `0.6.3` as the latest published version, so a simple
+version bump does not solve this.
+
+## Current Usage
+
+Production code imports Aho-Corasick directly only in
+`no.rmz.rmatch.engine.prefilter.AhoCorasickPrefilter`:
+
+- `org.ahocorasick.trie.Trie`
+- `org.ahocorasick.trie.Emit`
+
+The public matcher API does not expose Aho-Corasick types. This is an internal
+implementation dependency used by the literal prefilter.
+
+## Options
+
+### Keep The Current State Until 2.0
+
+This is acceptable for a short-lived `1.9.x` release-candidate line. The Maven
+artifact works, Central accepts it, and consumer smoke tests pass.
+
+The cost is that the JPMS descriptor is useful but not pristine. We should keep
+the issue open and avoid overstating JPMS quality in release notes.
+
+### Remove `module-info.java` And Publish `Automatic-Module-Name`
+
+This would avoid the `javac` warning because `rmatch` would again be compiled as
+a classpath library while still advertising a stable module name in the JAR
+manifest.
+
+This is the cleanest low-risk option if we decide that `1.9.x` should not carry
+any JPMS warning. It is also a step back from explicit JPMS, so it should be a
+conscious compatibility decision rather than a quiet fix.
+
+### Shade The Existing Dependency
+
+Plain Maven shading after compilation is not enough. The warning is produced
+while compiling `module-info.java`; at that point `javac` still sees
+`ahocorasick-0.6.3.jar` as an automatic module.
+
+Shading can still help the public dependency surface, but it does not by itself
+make the explicit JPMS build clean. To solve the warning with shading, the
+classes would need to be internalized before module compilation or the module
+descriptor would need a more complex build path.
+
+### Replace Or Reimplement The Prefilter
+
+This is the most complete 2.0-quality solution. Since the dependency is used
+behind one internal class, we could replace it with:
+
+- a small internal Aho-Corasick implementation,
+- another library with explicit JPMS metadata,
+- or a different literal-prefilter design.
+
+This must go through functional tests and the agogo performance gate. The
+literal prefilter is performance-sensitive, so this should not be treated as a
+cosmetic dependency cleanup.
+
+### Vendor The Upstream Classes
+
+The upstream JAR is small, but vendoring third-party source creates licensing,
+maintenance, and audit obligations. It should be considered only if replacing or
+rewriting the prefilter is clearly worse.
+
+## Recommendation
+
+For `1.9.x`, keep the current state unless the warning starts blocking tooling
+or user confidence. For `2.0.0`, resolve issue #282 before claiming clean JPMS
+support.
+
+The preferred investigation path is:
+
+1. Build a replacement/internal prefilter behind the existing
+   `AhoCorasickPrefilter` behavior.
+2. Run the full functional suite.
+3. Run the agogo performance gate against the current Aho-backed implementation.
+4. If performance is acceptable, remove the Aho-Corasick dependency and the
+   `requires ahocorasick` directive.
+5. If performance is not acceptable, either keep the dependency and document the
+   JPMS caveat, or fall back to `Automatic-Module-Name` until a better
+   dependency-boundary solution exists.

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -189,10 +189,12 @@ the rest of the release work here as it becomes explicit.
   classes package-private or private where possible, prefer final classes for
   non-extension APIs, and verify that README/Javadocs teach factory/interface
   usage rather than direct implementation construction.
-- [ ] Before publishing a JPMS-bearing release, resolve or explicitly accept the
-  Aho-Corasick automatic-module warning emitted by `javac`; do not treat the
-  module descriptor as fully clean until this dependency-boundary decision is
-  recorded.
+- [ ] Before publishing a JPMS-bearing `2.0.0` release, resolve or explicitly
+  accept the Aho-Corasick automatic-module warning emitted by `javac`; do not
+  treat the module descriptor as fully clean until this dependency-boundary
+  decision is recorded. Track this under
+  [issue #282](https://github.com/la3lma/rmatch/issues/282) and
+  [the JPMS/Aho-Corasick boundary note](design/jpms-aho-corasick-boundary.md).
 - [x] Set release POM versions to `1.9.1` on the release-prep branch.
 - [x] Ensure parent and library POMs have name, description, URL, licenses,
   developers, organization, and SCM metadata.


### PR DESCRIPTION
Documents the investigation for #282: why the JPMS automatic-module warning happens, why a simple dependency bump or ordinary shade-after-compile pass does not solve it, and what the realistic pre-2.0 options are.\n\nValidation:\n- Synced local main to origin/main first; prior dirty local state was stashed as a safety backup.\n- Reproduced the Central-profile warning.\n- Confirmed org.ahocorasick:ahocorasick:0.6.3 is latest and has no module descriptor or Automatic-Module-Name.\n- Ran ./mvnw -q -B -pl rmatch -am -DskipTests -Dspotbugs.skip=true verify.