### PR TITLE
Replace Aho-Corasick dependency with internal prefilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## 1.9.4-SNAPSHOT - in development
 
-- No changes yet.
+- Replaced the external `org.ahocorasick:ahocorasick` literal-prefilter
+  dependency with a small internal Aho-Corasick implementation. The original
+  library served rmatch well and deserves credit; the replacement is about
+  keeping the pre-2.0 JPMS and Maven Central boundary clean as the project
+  moves forward.
+- Removed the `requires ahocorasick` JPMS dependency and the compile-scope
+  Maven dependency. Local Central-profile verification no longer emits the
+  filename-derived automatic-module warning.
+- Verified the replacement on agogo against the Aho-backed baseline using the
+  stable 10K-pattern Docker gate. Median scan-time ratios were 1.015 on 1MB and
+  1.004 on 10MB with identical match counts, so the replacement reaches parity
+  under the current release gate.
 
 ## 1.9.3 - pre-2.0 Maven Central release candidate
 

--- a/docs/design/jpms-aho-corasick-boundary.md
+++ b/docs/design/jpms-aho-corasick-boundary.md
@@ -124,11 +124,7 @@ rewriting the prefilter is clearly worse.
 
 ## Recommendation
 
-For `1.9.x`, keep the current state unless the warning starts blocking tooling
-or user confidence. For `2.0.0`, resolve issue #282 before claiming clean JPMS
-support.
-
-The preferred investigation path is:
+Initial recommendation before implementation:
 
 1. Build a replacement/internal prefilter behind the existing
    `AhoCorasickPrefilter` behavior.
@@ -139,3 +135,83 @@ The preferred investigation path is:
 5. If performance is not acceptable, either keep the dependency and document the
    JPMS caveat, or fall back to `Automatic-Module-Name` until a better
    dependency-boundary solution exists.
+
+## Implementation Result
+
+Branch `u/la3lma/codex/issue-282-internal-prefilter` follows that path. It
+keeps the `AhoCorasickPrefilter` API but replaces the external library with a
+small internal trie plus failure-link implementation tailored to rmatch's
+literal-hint model.
+
+The original `org.ahocorasick:ahocorasick` library did the job well for rmatch
+for a long time, and deserves explicit credit for that. The reason to move on is
+not that it was bad code; it is that time does not stand still. rmatch now has
+an explicit JPMS story, Maven Central publication, and a tighter pre-2.0 public
+surface. A filename-derived automatic module is the wrong long-term boundary for
+an implementation-only prefilter.
+
+Local validation on 2026-07-08:
+
+```bash
+./mvnw -B -pl rmatch -am verify -Dspotbugs.skip=true
+```
+
+Result:
+
+- 335 tests passed; 0 failures; 0 errors; 3 skipped.
+- The bounded micro-guard in `AhoCorasickPrefilterPerformanceTest` reported
+  `Naive=120.41 ms, Internal Aho-Corasick=15.54 ms, Improvement=87.09%`.
+
+Central-profile validation:
+
+```bash
+./mvnw -B -pl rmatch -am -Pcentral-release \
+  -DskipTests -Dspotbugs.skip=true -Dgpg.skip=true clean verify
+```
+
+Result:
+
+- Build succeeded.
+- The filename-based automatic-module warning disappeared.
+
+Compile dependency tree:
+
+```text
+no.rmz:rmatch:jar:1.9.4-SNAPSHOT
+```
+
+No compile-scope third-party dependency remains in `no.rmz:rmatch`.
+
+External agogo performance gate on 2026-07-08:
+
+- Host hardware: 32 logical CPUs, AMD Ryzen 9 9950X3D.
+- Docker image: `maven:3.9-eclipse-temurin-26`.
+- Harness: `rmatch-perftest`,
+  `test_matrix/stable_10k_moderate_rmatch.json`.
+- Baseline: `origin/main` after PR #283, using the existing Aho-backed
+  implementation.
+- Candidate: branch `u/la3lma/codex/issue-282-internal-prefilter`, using the
+  internal implementation.
+- Both runs used identical generated pattern files and pinned 1MB/10MB
+  synthetic corpora.
+
+Result directories on agogo:
+
+```text
+/home/rmz/git/rmatch-agogo-issue-282-internal-prefilter-20260708_172435/rmatch-perftest/benchmarking/framework/regex_bench_framework/results/agogo_issue_282_baseline_aho_fixed_20260708_153744
+/home/rmz/git/rmatch-agogo-issue-282-internal-prefilter-20260708_172435/rmatch-perftest/benchmarking/framework/regex_bench_framework/results/agogo_issue_282_candidate_internal_fixed_20260708_154048
+```
+
+Gate result:
+
+```text
+1MB:  baseline_ms=2437.950  candidate_ms=2474.760  ratio=1.015
+      match_count=19,234,521 for both runs
+10MB: baseline_ms=19233.018 candidate_ms=19315.342 ratio=1.004
+      match_count=192,371,384 for both runs
+PERF_GATE=PASS
+```
+
+The replacement reaches parity with the existing prefilter under the current
+agogo gate and removes the JPMS automatic-module warning. That is enough to
+move the implementation to PR review and close #282 once merged.

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -189,12 +189,19 @@ the rest of the release work here as it becomes explicit.
   classes package-private or private where possible, prefer final classes for
   non-extension APIs, and verify that README/Javadocs teach factory/interface
   usage rather than direct implementation construction.
-- [ ] Before publishing a JPMS-bearing `2.0.0` release, resolve or explicitly
+- [x] Before publishing a JPMS-bearing `2.0.0` release, resolve or explicitly
   accept the Aho-Corasick automatic-module warning emitted by `javac`; do not
   treat the module descriptor as fully clean until this dependency-boundary
   decision is recorded. Track this under
   [issue #282](https://github.com/la3lma/rmatch/issues/282) and
   [the JPMS/Aho-Corasick boundary note](design/jpms-aho-corasick-boundary.md).
+  Result on 2026-07-08: branch
+  `u/la3lma/codex/issue-282-internal-prefilter` replaces the implementation-only
+  `org.ahocorasick:ahocorasick` dependency with an internal Aho-Corasick
+  prefilter, removes `requires ahocorasick`, and makes the Central-profile
+  build warning-free. The agogo Docker gate against the Aho-backed baseline
+  passed on a 32-logical-CPU AMD Ryzen 9 9950X3D host with identical match
+  counts. Median `scanning_ns` ratios were 1.015 on 1MB and 1.004 on 10MB.
 - [x] Set release POM versions to `1.9.1` on the release-prep branch.
 - [x] Ensure parent and library POMs have name, description, URL, licenses,
   developers, organization, and SCM metadata.

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <properties>
         <maven.plugin.validation>DEFAULT</maven.plugin.validation>
         <java.version>21</java.version>
-        <ahocorasick.version>0.6.3</ahocorasick.version>
         <jmh.version>1.37</jmh.version>
         <junit-jupiter.version>6.1.1</junit-jupiter.version>
         <junit-platform.version>6.1.1</junit-platform.version>
@@ -119,13 +118,6 @@
                 <artifactId>junit-platform-launcher</artifactId>
                 <version>${junit-platform.version}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <!-- Third-party Libraries -->
-            <dependency>
-                <groupId>org.ahocorasick</groupId>
-                <artifactId>ahocorasick</artifactId>
-                <version>${ahocorasick.version}</version>
             </dependency>
 
             <!-- JMH for benchmarks -->

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -34,11 +34,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.ahocorasick</groupId>
-            <artifactId>ahocorasick</artifactId>
-            <version>${ahocorasick.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/rmatch/src/main/java/module-info.java
+++ b/rmatch/src/main/java/module-info.java
@@ -1,7 +1,6 @@
 module no.rmz.rmatch {
   requires java.logging;
   requires java.management;
-  requires ahocorasick;
 
   exports no.rmz.rmatch.compiler;
   exports no.rmz.rmatch.impls;

--- a/rmatch/src/main/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilter.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilter.java
@@ -13,9 +13,14 @@
  */
 package no.rmz.rmatch.engine.prefilter;
 
-import java.util.*;
-import org.ahocorasick.trie.Emit;
-import org.ahocorasick.trie.Trie;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * Aho-Corasick based prefilter for fast literal substring matching.
@@ -23,6 +28,12 @@ import org.ahocorasick.trie.Trie;
  * <p>This class builds an Aho-Corasick automaton from literal hints extracted from regex patterns.
  * It can then scan input text efficiently to find all occurrences of the literals, providing
  * candidate positions where regex matching should be attempted.
+ *
+ * <p>Earlier rmatch versions delegated this job to Robert Bor's excellent {@code
+ * org.ahocorasick:ahocorasick} library. We now keep a small internal implementation because Java's
+ * module system cannot treat that library as a stable explicit module. The algorithmic debt and
+ * credit remain exactly where they belong: this is the classic Aho-Corasick construction, adapted
+ * narrowly to rmatch's literal-prefilter needs because time does not stand still.
  *
  * <p>Example usage:
  *
@@ -88,7 +99,7 @@ public final class AhoCorasickPrefilter {
   }
 
   /** The Aho-Corasick trie for efficient string matching. */
-  private final Trie trie;
+  private final List<Node> nodes = new ArrayList<>();
 
   /** Map from literal string to the pattern hints that contain it. */
   private final Map<String, Bucket> buckets = new HashMap<>();
@@ -101,21 +112,21 @@ public final class AhoCorasickPrefilter {
    * @param hints the literal hints to build the automaton from
    */
   public AhoCorasickPrefilter(final Collection<LiteralHint> hints) {
-    final Trie.TrieBuilder builder = Trie.builder(); // Allow overlapping matches
+    nodes.add(new Node());
     final Map<String, List<LiteralHint>> tmpBuckets = new HashMap<>();
     // If any hint is case-insensitive, we'll add both cased variants at build time.
     for (final LiteralHint hint : hints) {
       for (final String key : keyedLiterals(hint)) {
         tmpBuckets.computeIfAbsent(key, k -> new ArrayList<>()).add(hint);
-        builder.addKeyword(key);
       }
     }
     for (final Map.Entry<String, List<LiteralHint>> entry : tmpBuckets.entrySet()) {
-      buckets.put(
-          entry.getKey(),
-          new Bucket(entry.getValue().toArray(LiteralHint[]::new), entry.getKey().length()));
+      final String key = entry.getKey();
+      final Bucket bucket = new Bucket(entry.getValue().toArray(LiteralHint[]::new), key.length());
+      buckets.put(key, bucket);
+      addKeyword(key, bucket);
     }
-    this.trie = builder.build();
+    buildFailureLinks();
   }
 
   /**
@@ -149,22 +160,81 @@ public final class AhoCorasickPrefilter {
    * @return list of candidate positions where regex matching should be attempted
    */
   public List<Candidate> scan(final CharSequence text) {
-    final String s = text.toString(); // AC needs String
     final List<Candidate> out = new ArrayList<>();
-    for (final Emit emit : trie.parseText(s)) {
-      final String keyword = emit.getKeyword();
-      final Bucket bucket = buckets.get(keyword);
-      if (bucket == null) {
-        continue;
+    int state = 0;
+    for (int i = 0; i < text.length(); i++) {
+      final char ch = text.charAt(i);
+      while (state != 0 && !nodes.get(state).transitions.containsKey(ch)) {
+        state = nodes.get(state).failure;
       }
-      final int endIdxExclusive = emit.getEnd() + 1;
-      final int literalLength = bucket.literalLength;
-      for (final LiteralHint hint : bucket.hints) {
-        out.add(
-            new Candidate(
-                hint.patternId(), endIdxExclusive, literalLength, hint.literalOffsetInMatch()));
+      final Integer next = nodes.get(state).transitions.get(ch);
+      state = next == null ? 0 : next;
+      final Node node = nodes.get(state);
+      if (!node.outputs.isEmpty()) {
+        final int endIdxExclusive = i + 1;
+        for (final Bucket bucket : node.outputs) {
+          for (final LiteralHint hint : bucket.hints) {
+            out.add(
+                new Candidate(
+                    hint.patternId(),
+                    endIdxExclusive,
+                    bucket.literalLength,
+                    hint.literalOffsetInMatch()));
+          }
+        }
       }
     }
     return out;
+  }
+
+  private void addKeyword(final String keyword, final Bucket bucket) {
+    int state = 0;
+    for (int i = 0; i < keyword.length(); i++) {
+      final char ch = keyword.charAt(i);
+      final Node node = nodes.get(state);
+      final Integer existing = node.transitions.get(ch);
+      if (existing != null) {
+        state = existing;
+      } else {
+        final int created = nodes.size();
+        nodes.add(new Node());
+        node.transitions.put(ch, created);
+        state = created;
+      }
+    }
+    nodes.get(state).outputs.add(bucket);
+  }
+
+  private void buildFailureLinks() {
+    final Queue<Integer> queue = new ArrayDeque<>();
+    final Node root = nodes.get(0);
+    for (final int child : root.transitions.values()) {
+      nodes.get(child).failure = 0;
+      queue.add(child);
+    }
+
+    while (!queue.isEmpty()) {
+      final int state = queue.remove();
+      final Node stateNode = nodes.get(state);
+      for (final Map.Entry<Character, Integer> transition : stateNode.transitions.entrySet()) {
+        final char ch = transition.getKey();
+        final int target = transition.getValue();
+
+        int fallback = stateNode.failure;
+        while (fallback != 0 && !nodes.get(fallback).transitions.containsKey(ch)) {
+          fallback = nodes.get(fallback).failure;
+        }
+        final Integer fallbackTarget = nodes.get(fallback).transitions.get(ch);
+        nodes.get(target).failure = fallbackTarget == null ? 0 : fallbackTarget;
+        nodes.get(target).outputs.addAll(nodes.get(nodes.get(target).failure).outputs);
+        queue.add(target);
+      }
+    }
+  }
+
+  private static final class Node {
+    private final Map<Character, Integer> transitions = new HashMap<>();
+    private final List<Bucket> outputs = new ArrayList<>();
+    private int failure;
   }
 }

--- a/rmatch/src/test/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilterPerformanceTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilterPerformanceTest.java
@@ -24,64 +24,62 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.IntStream;
-import org.ahocorasick.trie.Emit;
-import org.ahocorasick.trie.Trie;
 import org.junit.jupiter.api.Test;
 
 final class AhoCorasickPrefilterPerformanceTest {
 
   @Test
   void optimizedScanAvoidsSubstringCostOnLargeInputs() {
-    final int patternCount = 10_000;
+    final int patternCount = 1_000;
     final List<LiteralHint> hints =
         IntStream.range(0, patternCount)
             .mapToObj(i -> new LiteralHint(i, literalFor(i), 0, false, false, 0))
             .toList();
 
-    final String corpus = buildCorpus(patternCount, 60);
+    final String corpus = buildCorpus(patternCount, 20);
 
-    final AhoCorasickPrefilter optimized = new AhoCorasickPrefilter(hints);
-    final LegacyPrefilter legacy = new LegacyPrefilter(hints);
+    final AhoCorasickPrefilter internal = new AhoCorasickPrefilter(hints);
+    final NaivePrefilter naive = new NaivePrefilter(hints);
 
     // Warm-up to stabilize JVM effects.
     for (int i = 0; i < 3; i++) {
-      optimized.scan(corpus);
-      legacy.scan(corpus);
+      internal.scan(corpus);
+      naive.scan(corpus);
     }
 
     // Alternate call order to reduce warm-cache and JIT bias.
-    final List<Long> optimizedRuns = new ArrayList<>();
-    final List<Long> legacyRuns = new ArrayList<>();
+    final List<Long> internalRuns = new ArrayList<>();
+    final List<Long> naiveRuns = new ArrayList<>();
     final int rounds = 15;
     for (int i = 0; i < rounds; i++) {
       if ((i & 1) == 0) {
-        legacyRuns.add(measureOnce(legacy::scan, corpus));
-        optimizedRuns.add(measureOnce(optimized::scan, corpus));
+        naiveRuns.add(measureOnce(naive::scan, corpus));
+        internalRuns.add(measureOnce(internal::scan, corpus));
       } else {
-        optimizedRuns.add(measureOnce(optimized::scan, corpus));
-        legacyRuns.add(measureOnce(legacy::scan, corpus));
+        internalRuns.add(measureOnce(internal::scan, corpus));
+        naiveRuns.add(measureOnce(naive::scan, corpus));
       }
     }
 
-    final long optimizedNanos = median(optimizedRuns);
-    final long legacyNanos = median(legacyRuns);
+    final long internalNanos = median(internalRuns);
+    final long naiveNanos = median(naiveRuns);
 
     // Same candidates, faster scan.
-    final List<AhoCorasickPrefilter.Candidate> optimizedCandidates = optimized.scan(corpus);
-    final List<AhoCorasickPrefilter.Candidate> legacyCandidates = legacy.scan(corpus);
-    assertEquals(legacyCandidates.size(), optimizedCandidates.size());
+    final List<AhoCorasickPrefilter.Candidate> internalCandidates = sorted(internal.scan(corpus));
+    final List<AhoCorasickPrefilter.Candidate> naiveCandidates = sorted(naive.scan(corpus));
+    assertEquals(naiveCandidates, internalCandidates);
 
-    final double improvement = ((double) legacyNanos - optimizedNanos) / legacyNanos;
+    final double improvement = ((double) naiveNanos - internalNanos) / naiveNanos;
     System.out.printf(
         Locale.ROOT,
-        "Legacy=%.2f ms, Optimized=%.2f ms, Improvement=%.2f%%%n",
-        legacyNanos / 1_000_000.0,
-        optimizedNanos / 1_000_000.0,
+        "Naive=%.2f ms, Internal Aho-Corasick=%.2f ms, Improvement=%.2f%%%n",
+        naiveNanos / 1_000_000.0,
+        internalNanos / 1_000_000.0,
         improvement * 100.0);
     assertTrue(
-        optimizedNanos <= (long) (legacyNanos * 1.10),
+        internalNanos <= (long) (naiveNanos * 0.50),
         () ->
-            "Optimized scan should not regress materially (<=10% slower); improvement="
+            "Internal Aho-Corasick should comfortably beat naive scanning; improvement="
                 + String.format("%.2f%%", improvement * 100));
   }
 
@@ -96,6 +94,26 @@ final class AhoCorasickPrefilterPerformanceTest {
     final List<Long> sorted = new ArrayList<>(values);
     sorted.sort(Long::compareTo);
     return sorted.get(sorted.size() / 2);
+  }
+
+  private static List<AhoCorasickPrefilter.Candidate> sorted(
+      final List<AhoCorasickPrefilter.Candidate> candidates) {
+    final List<AhoCorasickPrefilter.Candidate> sorted = new ArrayList<>(candidates);
+    sorted.sort(AhoCorasickPrefilterPerformanceTest::compareCandidate);
+    return sorted;
+  }
+
+  private static int compareCandidate(
+      final AhoCorasickPrefilter.Candidate a, final AhoCorasickPrefilter.Candidate b) {
+    final int byEnd = Integer.compare(a.endIndexExclusive(), b.endIndexExclusive());
+    if (byEnd != 0) {
+      return byEnd;
+    }
+    final int byLength = Integer.compare(b.literalLength(), a.literalLength());
+    if (byLength != 0) {
+      return byLength;
+    }
+    return Integer.compare(a.patternId(), b.patternId());
   }
 
   private static String buildCorpus(final int patternCount, final int repeats) {
@@ -116,37 +134,34 @@ final class AhoCorasickPrefilterPerformanceTest {
     return "literal-" + suffix + "-payload-" + suffix + "-segment";
   }
 
-  private static final class LegacyPrefilter {
-    private final Trie trie;
+  private static final class NaivePrefilter {
     private final Map<String, List<LiteralHint>> buckets = new HashMap<>();
 
-    LegacyPrefilter(final Collection<LiteralHint> hints) {
-      final Trie.TrieBuilder builder = Trie.builder();
+    NaivePrefilter(final Collection<LiteralHint> hints) {
       for (final LiteralHint hint : hints) {
         for (final String key : keyedLiterals(hint)) {
           buckets.computeIfAbsent(key, k -> new ArrayList<>()).add(hint);
-          builder.addKeyword(key);
         }
       }
-      this.trie = builder.build();
     }
 
     List<AhoCorasickPrefilter.Candidate> scan(final CharSequence text) {
       final String s = text.toString();
       final List<AhoCorasickPrefilter.Candidate> out = new ArrayList<>();
-      for (final Emit emit : trie.parseText(s)) {
-        final String lit = s.substring(emit.getStart(), emit.getEnd() + 1);
-        final List<LiteralHint> hints = buckets.get(lit);
-        if (hints == null) {
-          continue;
-        }
-        final int endIdxExclusive = emit.getEnd() + 1;
-        for (final LiteralHint hint : hints) {
-          out.add(
-              new AhoCorasickPrefilter.Candidate(
-                  hint.patternId(), endIdxExclusive, lit.length(), hint.literalOffsetInMatch()));
+      for (final Map.Entry<String, List<LiteralHint>> entry : buckets.entrySet()) {
+        final String lit = entry.getKey();
+        int start = s.indexOf(lit);
+        while (start >= 0) {
+          final int endIdxExclusive = start + lit.length();
+          for (final LiteralHint hint : entry.getValue()) {
+            out.add(
+                new AhoCorasickPrefilter.Candidate(
+                    hint.patternId(), endIdxExclusive, lit.length(), hint.literalOffsetInMatch()));
+          }
+          start = s.indexOf(lit, start + 1);
         }
       }
+      out.sort(AhoCorasickPrefilterPerformanceTest::compareCandidate);
       return out;
     }
   }

--- a/rmatch/src/test/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilterTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/engine/prefilter/AhoCorasickPrefilterTest.java
@@ -83,6 +83,38 @@ public class AhoCorasickPrefilterTest {
   }
 
   @Test
+  public void testScanSuffixMatchesThroughFailureLinks() {
+    final List<LiteralHint> hints =
+        Arrays.asList(
+            new LiteralHint(1, "she", 0, false, false, 0),
+            new LiteralHint(2, "he", 0, false, false, 0),
+            new LiteralHint(3, "hers", 0, false, false, 0));
+    final AhoCorasickPrefilter prefilter = new AhoCorasickPrefilter(hints);
+    final List<AhoCorasickPrefilter.Candidate> candidates = prefilter.scan("ushers");
+
+    assertEquals(3, candidates.size());
+    assertTrue(candidates.stream().anyMatch(c -> c.patternId() == 1 && c.endIndexExclusive() == 4));
+    assertTrue(candidates.stream().anyMatch(c -> c.patternId() == 2 && c.endIndexExclusive() == 4));
+    assertTrue(candidates.stream().anyMatch(c -> c.patternId() == 3 && c.endIndexExclusive() == 6));
+  }
+
+  @Test
+  public void testScanNestedPrefixMatches() {
+    final List<LiteralHint> hints =
+        Arrays.asList(
+            new LiteralHint(1, "a", 0, false, false, 0),
+            new LiteralHint(2, "aa", 0, false, false, 0),
+            new LiteralHint(3, "aaa", 0, false, false, 0));
+    final AhoCorasickPrefilter prefilter = new AhoCorasickPrefilter(hints);
+    final List<AhoCorasickPrefilter.Candidate> candidates = prefilter.scan("aaaa");
+
+    assertEquals(9, candidates.size());
+    assertEquals(4, candidates.stream().filter(c -> c.patternId() == 1).count());
+    assertEquals(3, candidates.stream().filter(c -> c.patternId() == 2).count());
+    assertEquals(2, candidates.stream().filter(c -> c.patternId() == 3).count());
+  }
+
+  @Test
   public void testScanCaseInsensitive() {
     final List<LiteralHint> hints = Arrays.asList(new LiteralHint(1, "FOO", 0, false, true, 0));
     final AhoCorasickPrefilter prefilter = new AhoCorasickPrefilter(hints);


### PR DESCRIPTION
## Summary

Replaces the implementation-only `org.ahocorasick:ahocorasick` dependency with a small internal Aho-Corasick prefilter behind the existing `AhoCorasickPrefilter` API.

This gives full credit to Robert Bor's original Aho-Corasick library, which served rmatch well. The reason to move on is not that it was bad code; it is that time does not stand still: rmatch now has explicit JPMS metadata and Maven Central release hygiene, and a filename-derived automatic module is not the boundary we want before 2.0.

Closes #282 once merged.

## What changed

- Removed the compile-scope `org.ahocorasick:ahocorasick` dependency.
- Removed `requires ahocorasick` from `module-info.java`.
- Added an internal trie/failure-link implementation tailored to rmatch literal hints.
- Added correctness coverage for suffix/failure-link matches and nested-prefix overlaps.
- Updated the release checklist, design note, and changelog with validation receipts.

## Validation

- `./mvnw -B -pl rmatch -am verify -Dspotbugs.skip=true`
  - 335 tests, 0 failures, 0 errors, 3 skipped.
  - Local micro-guard: `Naive=120.41 ms, Internal Aho-Corasick=15.54 ms, Improvement=87.09%`.
- `./mvnw -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.skip=true clean verify`
  - Build succeeded.
  - No filename-derived automatic-module warning in filtered output.
- `./mvnw -pl rmatch dependency:tree -Dscope=compile`
  - `no.rmz:rmatch:jar:1.9.4-SNAPSHOT` with no compile-scope third-party dependency.
- Agogo Docker performance gate on 32 logical CPUs, AMD Ryzen 9 9950X3D, `maven:3.9-eclipse-temurin-26`, stable 10K-pattern matrix:
  - 1MB: baseline 2437.950 ms, candidate 2474.760 ms, ratio 1.015, identical match count 19,234,521.
  - 10MB: baseline 19233.018 ms, candidate 19315.342 ms, ratio 1.004, identical match count 192,371,384.
  - `PERF_GATE=PASS`.

## Notes

An earlier agogo run generated separate 10MB corpora for baseline and candidate, so its count comparison was invalid. I pinned a shared `corpus_synthetic_10MB.txt` before the final gate; both final runs explicitly reused identical 1MB and 10MB corpora.
