### PR TITLE
Fix the 2.0 shape of the per-pattern flags API

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -1,6 +1,8 @@
 name: Main Gate
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main, master]
     types: [opened, synchronize, reopened, ready_for_review]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 1.9.5-SNAPSHOT - in development
 
 - Continue pre-2.0 cleanup after publishing `1.9.4`.
+- Added the flags-capable registration API that fixes the 2.0 shape for
+  per-pattern options: `Matcher.add(String, Set<PatternFlag>, Action)` and the
+  matching `remove` overload, with `PatternFlag.CASE_INSENSITIVE` as the first
+  flag (equivalent to the `(?i)` prefix). Future matching modes join as new
+  enum constants, which is binary compatible.
+- The main CI gate now also runs on pushes to `main`, and the README carries
+  its status badge.
 - Specified and enforced the matcher behavioral contracts for 2.0: action
   exceptions abort the scan and propagate out of `match()` (partitioned
   matchers finish the surviving partitions, then rethrow the first failure

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/no.rmz/rmatch.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/no.rmz/rmatch)
 [![Javadocs](https://javadoc.io/badge2/no.rmz/rmatch/javadoc.svg)](https://javadoc.io/doc/no.rmz/rmatch)
+[![Main Gate](https://github.com/la3lma/rmatch/actions/workflows/main-gate.yml/badge.svg?branch=main)](https://github.com/la3lma/rmatch/actions/workflows/main-gate.yml)
 
 `rmatch` is a Java library for matching many regular expressions against large
 text buffers with one pass-oriented matching pipeline. It is aimed at workloads
@@ -240,7 +241,9 @@ is not a drop-in replacement for `java.util.regex` or PCRE.
 - Word boundaries: `\b` and `\B` using ASCII word semantics aligned with
   `\w`: letters, digits, and underscore are word characters.
 - Pattern-prefix flags: `(?i)` for case-insensitive matching; `(?s)` is
-  accepted because `.` is already DOTALL
+  accepted because `.` is already DOTALL. Programmatic registration can use
+  `matcher.add(pattern, Set.of(PatternFlag.CASE_INSENSITIVE), action)`
+  instead of splicing prefixes into pattern strings
 
 ## Important Limitations
 

--- a/docs/regex-syntax-roadmap.md
+++ b/docs/regex-syntax-roadmap.md
@@ -54,7 +54,9 @@ bugs: negated sets were unsound, and matches could forget earlier final states.
 1. Grouping `( … )` / `(?: … )` — unlocks composition, parser-only.
 2. `\d \w \s` + escapes — biggest wild-pattern coverage per line of code.
 3. `{m,n}` with an explicit expansion bound.
-4. Case-insensitivity as an `add(pattern, flags, action)` API flag.
+4. Case-insensitivity as an `add(pattern, flags, action)` API flag — shipped
+   as `PatternFlag.CASE_INSENSITIVE` with the flags-capable `add`/`remove`
+   overloads (2026-07-10).
 5. `\b` / `\B` — implemented under issue #270.
 6. Input anchors, mode flags, and pure zero-width reporting — future work.
 

--- a/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
@@ -13,6 +13,8 @@
  */
 package no.rmz.rmatch;
 
+import java.util.Set;
+
 /**
  * Main public API for registering regular expressions and matching them against buffers.
  *
@@ -61,6 +63,25 @@ public interface Matcher extends AutoCloseable {
   void add(final String r, final Action a) throws RegexpParserException;
 
   /**
+   * Register a regular expression with per-pattern option flags.
+   *
+   * <p>Flags express the same semantics as the corresponding inline syntax; for example {@link
+   * PatternFlag#CASE_INSENSITIVE} is equivalent to prefixing the pattern with {@code (?i)}. The
+   * flagged registration is identified by the combination of pattern and flags, so a later {@link
+   * #remove(String, Set, Action)} must supply the same flags.
+   *
+   * @param r regular-expression text in the rmatch supported syntax subset
+   * @param flags per-pattern option flags; may be empty
+   * @param a action to run for each match
+   * @throws RegexpParserException if {@code r} cannot be parsed by the supported rmatch syntax
+   * @throws IllegalStateException if the matcher has been closed
+   */
+  default void add(final String r, final Set<PatternFlag> flags, final Action a)
+      throws RegexpParserException {
+    add(PatternFlag.applyTo(r, flags), a);
+  }
+
+  /**
    * Remove one association between a regular expression and an action.
    *
    * <p>If the same expression has several actions, only the supplied expression/action pair is
@@ -71,6 +92,20 @@ public interface Matcher extends AutoCloseable {
    * @throws IllegalStateException if the matcher has been closed
    */
   void remove(final String r, final Action a);
+
+  /**
+   * Remove an expression/action pair that was registered with flags.
+   *
+   * <p>The flags must equal the flags used at registration time.
+   *
+   * @param r regular-expression text previously registered with {@link #add(String, Set, Action)}
+   * @param flags flags supplied when the pair was registered
+   * @param a action previously associated with {@code r}
+   * @throws IllegalStateException if the matcher has been closed
+   */
+  default void remove(final String r, final Set<PatternFlag> flags, final Action a) {
+    remove(PatternFlag.applyTo(r, flags), a);
+  }
 
   /**
    * Scan the supplied buffer with all currently registered expressions.

--- a/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
@@ -71,7 +71,7 @@ public interface Matcher extends AutoCloseable {
    * #remove(String, Set, Action)} must supply the same flags.
    *
    * @param r regular-expression text in the rmatch supported syntax subset
-   * @param flags per-pattern option flags; may be empty
+   * @param flags per-pattern option flags; an empty or {@code null} set means no flags
    * @param a action to run for each match
    * @throws RegexpParserException if {@code r} cannot be parsed by the supported rmatch syntax
    * @throws IllegalStateException if the matcher has been closed

--- a/rmatch/src/main/java/no/rmz/rmatch/PatternFlag.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/PatternFlag.java
@@ -43,14 +43,14 @@ public enum PatternFlag {
    * Rewrite a pattern so the supplied flags are expressed in inline syntax.
    *
    * <p>Flags are prepended in declaration order, so the rewritten pattern is deterministic for a
-   * given flag set. An empty flag set returns the pattern unchanged.
+   * given flag set. An empty or {@code null} flag set returns the pattern unchanged.
    *
    * @param regex pattern text in the rmatch supported syntax subset
-   * @param flags flags to apply
+   * @param flags flags to apply; {@code null} is treated as empty
    * @return pattern text with the flags expressed as inline prefixes
    */
   static String applyTo(final String regex, final Set<PatternFlag> flags) {
-    if (flags.isEmpty()) {
+    if (flags == null || flags.isEmpty()) {
       return regex;
     }
     final StringBuilder sb = new StringBuilder();

--- a/rmatch/src/main/java/no/rmz/rmatch/PatternFlag.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/PatternFlag.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch;
+
+import java.util.Set;
+
+/**
+ * Per-pattern option flags for {@link Matcher#add(String, Set, Action)}.
+ *
+ * <p>This enum fixes the shape of the flags API for the 2.0 line: future matching modes join as new
+ * constants, which is a binary-compatible change, so the {@code Matcher} interface never needs
+ * another overload for them. Flags express the same semantics as the corresponding inline pattern
+ * syntax; they exist so that programmatically assembled pattern sets do not have to splice mode
+ * prefixes into pattern strings.
+ */
+public enum PatternFlag {
+
+  /**
+   * Match without regard to letter case, equivalent to prefixing the pattern with {@code (?i)}.
+   * Case folding happens at compile time; the scan path is unchanged.
+   */
+  CASE_INSENSITIVE("(?i)");
+
+  /** Inline-syntax prefix expressing this flag. */
+  private final String inlinePrefix;
+
+  PatternFlag(final String inlinePrefix) {
+    this.inlinePrefix = inlinePrefix;
+  }
+
+  /**
+   * Rewrite a pattern so the supplied flags are expressed in inline syntax.
+   *
+   * <p>Flags are prepended in declaration order, so the rewritten pattern is deterministic for a
+   * given flag set. An empty flag set returns the pattern unchanged.
+   *
+   * @param regex pattern text in the rmatch supported syntax subset
+   * @param flags flags to apply
+   * @return pattern text with the flags expressed as inline prefixes
+   */
+  static String applyTo(final String regex, final Set<PatternFlag> flags) {
+    if (flags.isEmpty()) {
+      return regex;
+    }
+    final StringBuilder sb = new StringBuilder();
+    for (final PatternFlag flag : values()) {
+      if (flags.contains(flag)) {
+        sb.append(flag.inlinePrefix);
+      }
+    }
+    return sb.append(regex).toString();
+  }
+}

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
@@ -48,6 +48,19 @@ public class PatternFlagUsageTest {
   }
 
   @Test
+  public void nullFlagSetBehavesLikePlainAdd() throws Exception {
+    try (Matcher m = RMatch.newSingleMatcher()) {
+      final Set<String> found = new TreeSet<>();
+      m.add("warn", (Set<PatternFlag>) null, (b, start, end) -> found.add(b.getString(start, end)));
+
+      m.match(RMatch.stringBuffer("warn WARN"));
+
+      assertEquals(
+          Set.of("warn"), found, "null flags mean no flags; matching stays case-sensitive");
+    }
+  }
+
+  @Test
   public void emptyFlagSetBehavesLikePlainAdd() throws Exception {
     try (Matcher m = RMatch.newSingleMatcher()) {
       final Set<String> found = new TreeSet<>();

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch.ordinaryuse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import no.rmz.rmatch.Matcher;
+import no.rmz.rmatch.PatternFlag;
+import no.rmz.rmatch.RMatch;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the flags-capable {@link Matcher#add(String, Set, no.rmz.rmatch.Action)} overload,
+ * which fixes the 2.0 shape of the per-pattern flags API.
+ */
+public class PatternFlagUsageTest {
+
+  @Test
+  public void caseInsensitiveFlagMatchesAllCases() throws Exception {
+    try (Matcher m = RMatch.newSingleMatcher()) {
+      final Set<String> found = new TreeSet<>();
+      m.add(
+          "warn",
+          Set.of(PatternFlag.CASE_INSENSITIVE),
+          (b, start, end) -> found.add(b.getString(start, end)));
+
+      m.match(RMatch.stringBuffer("warn Warn WARN warned"));
+
+      assertTrue(found.contains("warn"), "lowercase form should match");
+      assertTrue(found.contains("Warn"), "mixed-case form should match");
+      assertTrue(found.contains("WARN"), "uppercase form should match");
+    }
+  }
+
+  @Test
+  public void emptyFlagSetBehavesLikePlainAdd() throws Exception {
+    try (Matcher m = RMatch.newSingleMatcher()) {
+      final Set<String> found = new TreeSet<>();
+      m.add("warn", Set.of(), (b, start, end) -> found.add(b.getString(start, end)));
+
+      m.match(RMatch.stringBuffer("warn WARN"));
+
+      assertEquals(Set.of("warn"), found, "without flags, matching stays case-sensitive");
+    }
+  }
+
+  @Test
+  public void removeWithSameFlagsRemovesTheRegistration() throws Exception {
+    try (Matcher m = RMatch.newSingleMatcher()) {
+      final Set<String> found = new TreeSet<>();
+      final no.rmz.rmatch.Action action = (b, start, end) -> found.add(b.getString(start, end));
+
+      m.add("warn", Set.of(PatternFlag.CASE_INSENSITIVE), action);
+      m.remove("warn", Set.of(PatternFlag.CASE_INSENSITIVE), action);
+
+      m.match(RMatch.stringBuffer("warn WARN"));
+
+      assertEquals(Set.of(), found, "removed registration must not fire");
+    }
+  }
+
+  @Test
+  public void flaggedAddWorksOnPartitionedMatcher() throws Exception {
+    try (Matcher m = RMatch.newMatcher()) {
+      final Set<String> found = new ConcurrentSkipListSet<>();
+      m.add(
+          "warn",
+          Set.of(PatternFlag.CASE_INSENSITIVE),
+          (b, start, end) -> found.add(b.getString(start, end)));
+
+      m.match(RMatch.stringBuffer("warn Warn WARN"));
+
+      assertEquals(Set.of("warn", "Warn", "WARN"), found);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `PatternFlag` enum (first constant: `CASE_INSENSITIVE`, equivalent to the `(?i)` prefix) plus flags-capable default overloads `Matcher.add(String, Set<PatternFlag>, Action)` and the matching `remove`.
- Freezes the flags API shape for 2.0: future matching modes join as enum constants (binary compatible), so `Matcher` never needs another overload for them.
- Compile-path only — flags rewrite the pattern string at registration; no engine or scan-path change, so no external perf gate needed (CI canary covers correctness at scale).
- Main Gate now also runs on pushes to `main`; README carries its status badge.

Tests: `PatternFlagUsageTest` covers case-insensitive matching via flag, empty-set equivalence with plain `add`, flagged `remove` symmetry, and the partitioned matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)