### PR TITLE
Use repository project token for Codacy coverage upload

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -110,16 +110,8 @@ jobs:
         continue-on-error: true
         # v1 — pinned to a commit SHA per supply-chain hardening practice
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
-        env:
-          # The stored secret is an account-level API token (verified by
-          # probe: /api/v3/user answers 200), so the reporter runs in
-          # api-token mode with explicit repository coordinates.
-          CODACY_API_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: gh
-          CODACY_USERNAME: la3lma
-          CODACY_PROJECT_NAME: rmatch
         with:
-          api-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: rmatch/target/site/jacoco/jacoco.xml
 
       - name: Report upload outcome


### PR DESCRIPTION
The secret now holds the repo-scoped project token, so the reporter runs in plain project-token mode; account-token coordinates removed. Upload remains non-blocking with loud outcome reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)