### PR TITLE
Apply focused Codacy cleanup

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -55,8 +55,21 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      # GitHub code scanning now rejects a single SARIF upload containing
+      # multiple runs with the same category. Codacy can emit several runs, so
+      # assign a stable per-run category before upload.
+      - name: Normalize SARIF run categories
+        run: |
+          jq '
+            .runs = ((.runs // []) | to_entries | map(
+              .value.automationDetails = ((.value.automationDetails // {}) + {id: ("codacy/" + (.key | tostring))})
+              | .value
+            ))
+          ' results.sarif > results-normalized.sarif
+          mv results-normalized.sarif results.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>rmatch 2.0 release checklist</title>
+  <title>2.0-release-checklist</title>
   <style>
     /* Default styles provided by pandoc.
     ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
@@ -172,9 +172,6 @@
   </style>
 </head>
 <body>
-<header id="title-block-header">
-<h1 class="title">rmatch 2.0 release checklist</h1>
-</header>
 <h1 id="rmatch-2.0-release-checklist">rmatch 2.0 release checklist</h1>
 <p>This is the broad pre-2.0 checklist. It is intentionally
 over-inclusive: assume items here should be completed unless they are
@@ -418,6 +415,10 @@ fixed during the 1.9.x line.</label></li>
 <li><label><input type="checkbox" />Add or verify a GitHub Actions
 workflow that runs the full Maven test suite on pull
 requests.</label></li>
+<li><label><input type="checkbox" />Review Codacy critical/high findings
+manually; fix real command/path, reflection, dead-code, and
+release-hygiene issues, and explicitly reject style-only false
+positives.</label></li>
 <li><label><input type="checkbox" />Ensure CI runs more than smoke tests
 before 2.0.</label></li>
 <li><label><input type="checkbox" />Review <code>main-gate.yml</code> or
@@ -452,6 +453,9 @@ byte-identical corpora and pattern sets.</label></li>
 and record the generator settings.</label></li>
 <li><label><input type="checkbox" />Require equal match counts before
 comparing timings.</label></li>
+<li><label><input type="checkbox" />Fail the high-core regression gate
+on any slowdown above 3% unless the regression is explicitly understood,
+justified, and accepted before release.</label></li>
 <li><label><input type="checkbox" />Capture raw benchmark receipts,
 summaries, and charts in
 <code>docs/benchmark-receipts/...</code>.</label></li>

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -165,6 +165,9 @@ items here should be completed unless they are explicitly removed before the
 
 - [ ] Add or verify a GitHub Actions workflow that runs the full Maven test
   suite on pull requests.
+- [ ] Review Codacy critical/high findings manually; fix real command/path,
+  reflection, dead-code, and release-hygiene issues, and explicitly reject
+  style-only false positives.
 - [ ] Ensure CI runs more than smoke tests before 2.0.
 - [ ] Review `main-gate.yml` or its successor and ensure it does not merely
   compile plus run a tiny smoke subset.
@@ -189,6 +192,8 @@ items here should be completed unless they are explicitly removed before the
   using byte-identical corpora and pattern sets.
 - [ ] Use deterministic benchmark inputs and record the generator settings.
 - [ ] Require equal match counts before comparing timings.
+- [ ] Fail the high-core regression gate on any slowdown above 3% unless the
+  regression is explicitly understood, justified, and accepted before release.
 - [ ] Capture raw benchmark receipts, summaries, and charts in
   `docs/benchmark-receipts/...`.
 - [ ] Update the README performance chart from a recent run of the current

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/BaselineManager.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/BaselineManager.java
@@ -23,9 +23,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 import no.rmz.rmatch.performancetests.utils.MatcherBenchmarker;
 
@@ -427,8 +427,8 @@ public final class BaselineManager {
     String osVersion = System.getProperty("os.version", "unknown");
 
     // Try to get git info (may fail in some environments)
-    String gitCommit = getGitInfo("rev-parse", "HEAD");
-    String gitBranch = getGitInfo("rev-parse", "--abbrev-ref", "HEAD");
+    String gitCommit = getGitCommit();
+    String gitBranch = getGitBranch();
 
     // Collect architecture info and normalization score
     String architectureId = "unknown";
@@ -445,7 +445,7 @@ public final class BaselineManager {
           no.rmz.rmatch.performancetests.utils.NormalizationBenchmark.runBenchmarkMedian(3);
 
       LOG.info("Architecture ID: " + architectureId);
-      LOG.info(String.format("Normalization score: %.2f ops/ms", normalizationScore));
+      LOG.info(String.format(Locale.ROOT, "Normalization score: %.2f ops/ms", normalizationScore));
 
     } catch (Exception e) {
       LOG.warning("Failed to collect architecture info: " + e.getMessage());
@@ -455,13 +455,17 @@ public final class BaselineManager {
         javaVersion, osName, osVersion, gitCommit, gitBranch, architectureId, normalizationScore);
   }
 
-  private static String getGitInfo(String... command) {
-    try {
-      List<String> fullCommand = new ArrayList<>();
-      fullCommand.add("git");
-      fullCommand.addAll(Arrays.asList(command));
+  private static String getGitCommit() {
+    return getGitInfo(new ProcessBuilder("git", "rev-parse", "HEAD"));
+  }
 
-      Process process = new ProcessBuilder(fullCommand).redirectErrorStream(true).start();
+  private static String getGitBranch() {
+    return getGitInfo(new ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD"));
+  }
+
+  private static String getGitInfo(final ProcessBuilder processBuilder) {
+    try {
+      Process process = processBuilder.redirectErrorStream(true).start();
 
       try (BufferedReader reader =
           new BufferedReader(

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/SystemInfo.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/utils/SystemInfo.java
@@ -15,6 +15,9 @@ package no.rmz.rmatch.performancetests.utils;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -84,19 +87,20 @@ public final class SystemInfo {
   private static void collectLinuxCpuInfo(Map<String, Object> info) {
     try {
       // Try lscpu first (more structured output)
-      String lscpuOutput = executeCommand("lscpu");
+      String lscpuOutput = executeCommand(new ProcessBuilder("lscpu"));
       if (lscpuOutput != null && !lscpuOutput.isEmpty()) {
         parseLscpuOutput(lscpuOutput, info);
       }
 
       // Also try to get CPU model from /proc/cpuinfo
-      String cpuInfoOutput = executeCommand("cat /proc/cpuinfo");
+      String cpuInfoOutput = readFileIfExists(Path.of("/proc/cpuinfo"));
       if (cpuInfoOutput != null && !cpuInfoOutput.isEmpty()) {
         parseCpuInfo(cpuInfoOutput, info);
       }
 
       // Get CPU frequency info if available
-      String freqInfo = executeCommand("cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq");
+      String freqInfo =
+          readFileIfExists(Path.of("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"));
       if (freqInfo != null && !freqInfo.isEmpty()) {
         try {
           long freqKhz = Long.parseLong(freqInfo.trim());
@@ -217,13 +221,14 @@ public final class SystemInfo {
    */
   private static void collectMacCpuInfo(Map<String, Object> info) {
     try {
-      String sysctlOutput = executeCommand("sysctl -a");
+      String sysctlOutput = executeCommand(new ProcessBuilder("sysctl", "-a"));
       if (sysctlOutput != null && !sysctlOutput.isEmpty()) {
         parseSysctlOutput(sysctlOutput, info);
       }
 
       // Try to get CPU brand string
-      String cpuBrand = executeCommand("sysctl -n machdep.cpu.brand_string");
+      String cpuBrand =
+          executeCommand(new ProcessBuilder("sysctl", "-n", "machdep.cpu.brand_string"));
       if (cpuBrand != null && !cpuBrand.isEmpty()) {
         info.put("cpu_model", cpuBrand.trim());
       }
@@ -284,7 +289,12 @@ public final class SystemInfo {
     try {
       String wmicOutput =
           executeCommand(
-              "wmic cpu get Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed /format:list");
+              new ProcessBuilder(
+                  "wmic",
+                  "cpu",
+                  "get",
+                  "Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed",
+                  "/format:list"));
       if (wmicOutput != null && !wmicOutput.isEmpty()) {
         parseWmicOutput(wmicOutput, info);
       }
@@ -368,16 +378,14 @@ public final class SystemInfo {
   }
 
   /**
-   * Executes a shell command and returns its output.
+   * Executes a fixed command and returns its output.
    *
-   * @param command Command to execute
+   * @param command command and arguments to execute, with no shell interpolation
    * @return Command output or null if failed
    */
-  private static String executeCommand(String command) {
-    Process process = null;
+  private static String executeCommand(final ProcessBuilder processBuilder) {
     try {
-      ProcessBuilder pb = new ProcessBuilder("sh", "-c", command);
-      process = pb.start();
+      Process process = processBuilder.start();
       StringBuilder output = new StringBuilder();
       StringBuilder errorOutput = new StringBuilder();
       // Read stdout and stderr fully to avoid deadlocks
@@ -407,21 +415,17 @@ public final class SystemInfo {
       return null;
     } catch (Exception e) {
       return null;
-    } finally {
-      if (process != null) {
-        try {
-          process.getInputStream().close();
-        } catch (Exception ignored) {
-        }
-        try {
-          process.getErrorStream().close();
-        } catch (Exception ignored) {
-        }
-        try {
-          process.getOutputStream().close();
-        } catch (Exception ignored) {
-        }
+    }
+  }
+
+  private static String readFileIfExists(final Path path) {
+    try {
+      if (Files.isRegularFile(path)) {
+        return Files.readString(path, StandardCharsets.UTF_8);
       }
+      return null;
+    } catch (Exception e) {
+      return null;
     }
   }
 

--- a/rmatch/src/main/java/no/rmz/rmatch/compiler/CharRangeNode.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/compiler/CharRangeNode.java
@@ -46,8 +46,7 @@ final class CharRangeNode extends AbstractNDFANode {
     this.end = checkNotNull(end);
     this.next = checkNotNull(next);
     if (start.compareTo(end) > 0) {
-      // XXX Use something else than runtime exception.
-      throw new RuntimeException("Cannot have char range in which " + " end is  less than start");
+      throw new IllegalArgumentException("Cannot have a char range where end is less than start");
     }
   }
 

--- a/rmatch/src/main/java/no/rmz/rmatch/compiler/CompiledFragment.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/compiler/CompiledFragment.java
@@ -41,8 +41,7 @@ final class CompiledFragment {
    * @param endingNode If successful traversal of the NDFA, this node will be reached.
    */
   public CompiledFragment(final Regexp r, final NDFANode arrivalNode, final NDFANode endingNode) {
-    /** The regexp for which this is a compilation fragment. */
-    Regexp r1 = checkNotNull(r);
+    checkNotNull(r);
     this.arrivalNode = checkNotNull(arrivalNode);
     this.endingNode = checkNotNull(endingNode);
   }

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/DominationHeap.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/DominationHeap.java
@@ -18,7 +18,6 @@ import static no.rmz.rmatch.internal.Checks.checkState;
 
 import java.util.Comparator;
 import java.util.concurrent.PriorityBlockingQueue;
-import java.util.logging.Logger;
 import no.rmz.rmatch.interfaces.Match;
 
 /**
@@ -29,8 +28,6 @@ import no.rmz.rmatch.interfaces.Match;
  * actions are invoked.
  */
 final class DominationHeap {
-
-  private static final Logger LOG = Logger.getLogger(DominationHeap.class.getName());
 
   private final PriorityBlockingQueue<Match> heap;
 

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/FastPathMatchEngine.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/FastPathMatchEngine.java
@@ -150,8 +150,8 @@ final class FastPathMatchEngine implements MatchEngine {
   public void match(final Buffer b) {
     checkNotNull(b, "Buffer can't be null");
 
-    // Get thread-local buffers for state-set operations
-    final StateSetBuffers buffers = StateSetBuffers.get();
+    // Preserve the established fast-path warmup behavior without keeping an unused local.
+    StateSetBuffers.get();
 
     final Set<MatchSet> activeMatchSets = new HashSet<>();
 
@@ -209,6 +209,10 @@ final class FastPathMatchEngine implements MatchEngine {
     }
 
     activeMatchSets.clear();
+  }
+
+  boolean hasConfiguredPrefilterForTesting() {
+    return prefilter != null;
   }
 
   /**

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherImpl.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherImpl.java
@@ -75,7 +75,7 @@ final class MatcherImpl implements Matcher {
    * @param regexpFactory factory used to create internal regexp objects
    */
   MatcherImpl(final NDFACompiler compiler, final RegexpFactory regexpFactory) {
-    NDFACompiler compiler1 = checkNotNull(compiler);
+    checkNotNull(compiler);
     checkNotNull(regexpFactory);
     ns = new NodeStorageImpl();
     rs = new RegexpStorageImpl(ns, compiler, regexpFactory);

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
@@ -91,10 +91,8 @@ final class MultiMatcher implements Matcher {
   MultiMatcher(
       final int noOfMatchers, final NDFACompiler compiler, final RegexpFactory regexpFactory) {
 
-    /** The compiler used by all the matchers. */
-    NDFACompiler compiler1 = checkNotNull(compiler);
-    /** The regular expression factory used by all the matchers. */
-    RegexpFactory regexpFactory1 = checkNotNull(regexpFactory);
+    checkNotNull(compiler);
+    checkNotNull(regexpFactory);
     checkArgument(noOfMatchers >= 1, "No of partitions must be positive");
     checkArgument(
         noOfMatchers < MAX_NO_OF_MATCHERS,
@@ -187,7 +185,7 @@ final class MultiMatcher implements Matcher {
       counter.await();
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(ex);
+      throw new IllegalStateException("Interrupted while waiting for matcher partitions", ex);
     }
 
     final Throwable failure = firstFailure.get();
@@ -198,7 +196,7 @@ final class MultiMatcher implements Matcher {
       if (failure instanceof Error error) {
         throw error;
       }
-      throw new RuntimeException("Matcher partition failed", failure);
+      throw new IllegalStateException("Matcher partition failed", failure);
     }
   }
 

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/StartNode.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/StartNode.java
@@ -42,9 +42,6 @@ final class StartNode extends AbstractNDFANode {
   @SuppressWarnings("unchecked")
   private final DFANodeImpl topDFA = new DFANodeImpl(Collections.EMPTY_SET);
 
-  /** A monitor that is used to synchronize access to the StartNode instance. */
-  private final Object topDfaMonitor = new Object();
-
   /** Create a start node. */
   StartNode() {
     super(START_NO_REGEXP, false);

--- a/rmatch/src/main/java/no/rmz/rmatch/utils/SimulatedHeap.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/utils/SimulatedHeap.java
@@ -60,7 +60,8 @@ final class SimulatedHeap<T> {
   public void remove(final T m) {
     checkNotNull(m);
     if (!tm.containsKey(m)) {
-      throw new RuntimeException("Attempt to remove nonexisting " + "content from a SimulatedHeap");
+      throw new IllegalArgumentException(
+          "Attempt to remove nonexisting content from a SimulatedHeap");
     }
 
     checkArgument(true);

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/FastPathMatchEnginePrefilterThresholdTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/FastPathMatchEnginePrefilterThresholdTest.java
@@ -13,11 +13,10 @@
  */
 package no.rmz.rmatch.impls;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import no.rmz.rmatch.interfaces.NodeStorage;
@@ -35,7 +34,7 @@ final class FastPathMatchEnginePrefilterThresholdTest {
       final FastPathMatchEngine engine = new FastPathMatchEngine(mock(NodeStorage.class));
       engine.configurePrefilter(patterns(4999), flags(4999), regexpMappings(4999));
 
-      assertNull(readPrefilter(engine));
+      assertFalse(engine.hasConfiguredPrefilterForTesting());
     } finally {
       restoreSystemProperty("rmatch.prefilter", oldPrefilter);
     }
@@ -50,16 +49,10 @@ final class FastPathMatchEnginePrefilterThresholdTest {
       final FastPathMatchEngine engine = new FastPathMatchEngine(mock(NodeStorage.class));
       engine.configurePrefilter(patterns(5000), flags(5000), regexpMappings(5000));
 
-      assertNotNull(readPrefilter(engine));
+      assertTrue(engine.hasConfiguredPrefilterForTesting());
     } finally {
       restoreSystemProperty("rmatch.prefilter", oldPrefilter);
     }
-  }
-
-  private static Object readPrefilter(final FastPathMatchEngine engine) throws Exception {
-    final Field field = FastPathMatchEngine.class.getDeclaredField("prefilter");
-    field.setAccessible(true);
-    return field.get(engine);
   }
 
   private static Map<Integer, String> patterns(final int count) {


### PR DESCRIPTION
## Summary

This PR applies the Codacy findings that looked useful rather than hall-monitor noise:

- remove shell interpolation from system-info collection and use literal `ProcessBuilder` arguments
- keep git metadata collection explicit and locale-stable in the performance baseline manager
- remove several dead locals/fields and replace raw `RuntimeException` cases with more specific exceptions
- remove reflection from the prefilter threshold test by adding a package-private test probe
- update the Codacy security workflow for current GitHub code-scanning behavior (`checkout@v4`, `upload-sarif@v3`, distinct SARIF run categories)
- record Codacy triage and the high-core performance slowdown gate in the 2.0 checklist

One attempted hot-path cleanup was deliberately backed out before commit: removing the established `StateSetBuffers.get()` warmup caused a strict Agogo run to exceed the 3% slowdown gate on the 10MB corpus.

## Validation

Local checks:

- `./mvnw -q -B spotless:apply`
- `./mvnw -q -B verify`
- `git diff --check`

Agogo Docker performance gate:

- Host: high-core Agogo benchmark box, reported in receipts by hardware class rather than private machine name
- Image: `maven:3.9-eclipse-temurin-26`
- Config: `stable_10k_moderate_rmatch.json`
- Rule: equal match counts required; fail if candidate median `scanning_ns` is more than 3% slower than baseline
- Baseline: `origin/main` at `aad2ff5e`
- Candidate: this branch, including the final restored warmup behavior

Final gate result: PASS

- 1MB corpus: candidate/baseline ratio `0.932`, equal counts
- 10MB corpus: candidate/baseline ratio `1.018`, equal counts

The pre-restoration run failed at `1.054` on the 10MB corpus, which is exactly the sort of thing this gate should catch.
