### PR TITLE
Reject malformed regular expressions cleanly

### DIFF
--- a/rmatch/src/main/java/no/rmz/rmatch/compiler/SurfaceRegexpParser.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/compiler/SurfaceRegexpParser.java
@@ -202,9 +202,6 @@ final class SurfaceRegexpParser {
       commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
     }
 
-    // XXX Missing {m,n}, meaning "match at least m,
-    //     but no more than n times modifier.
-
     private void parseNextChar(char ch) throws RegexpParserException {
       final int atomStart = src.getIndex() - 1;
       switch (ch) {
@@ -214,9 +211,12 @@ final class SurfaceRegexpParser {
           lastAtomStart = -1;
           break;
         case '\\':
-          parseQuotedChar();
-          lastAtomStart = atomStart;
-          lastAtomEnd = src.getIndex();
+          if (parseQuotedChar()) {
+            lastAtomStart = atomStart;
+            lastAtomEnd = src.getIndex();
+          } else {
+            lastAtomStart = -1;
+          }
           break;
         case '.':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
@@ -227,22 +227,27 @@ final class SurfaceRegexpParser {
         case '^':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
           arb.addBeginningOfLine();
+          lastAtomStart = -1;
           break;
         case '$':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
           arb.addEndOfLine();
+          lastAtomStart = -1;
           break;
         case '?':
+          requireQuantifiableAtom(ch);
           commitForQuantifier();
           arb.addOptionalSingular();
           lastAtomStart = -1; // a quantified atom cannot take another counted quantifier
           break;
         case '*':
+          requireQuantifiableAtom(ch);
           commitForQuantifier();
           arb.addOptionalZeroOrMulti();
           lastAtomStart = -1;
           break;
         case '+':
+          requireQuantifiableAtom(ch);
           commitForQuantifier();
           arb.addOptionalOnceOrMulti();
           lastAtomStart = -1;
@@ -261,6 +266,7 @@ final class SurfaceRegexpParser {
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
           parseGroupStart();
           openGroupStarts.push(atomStart);
+          lastAtomStart = -1;
           break;
         case ')':
           if (groupDepth == 0) {
@@ -277,6 +283,12 @@ final class SurfaceRegexpParser {
           lastAtomStart = atomStart;
           lastAtomEnd = src.getIndex();
           break;
+      }
+    }
+
+    private void requireQuantifiableAtom(final char quantifier) throws RegexpParserException {
+      if (lastAtomStart < 0) {
+        throw new RegexpParserException("Quantifier '" + quantifier + "' has no preceding atom");
       }
     }
 
@@ -420,7 +432,7 @@ final class SurfaceRegexpParser {
       groupDepth++;
     }
 
-    private void parseQuotedChar() throws RegexpParserException {
+    private boolean parseQuotedChar() throws RegexpParserException {
       // KB-2: this condition was inverted, making EVERY escape throw.
       if (!src.hasNext()) {
         throw new RegexpParserException("Expected char after escape char: \\");
@@ -448,11 +460,11 @@ final class SurfaceRegexpParser {
         case 'b':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
           arb.addWordBoundary();
-          break;
+          return false;
         case 'B':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
           arb.addNonWordBoundary();
-          break;
+          return false;
         // Shorthand character classes: sugar over the existing charset machinery.
         case 'd', 'D', 'w', 'W', 's', 'S':
           commitCurrentString(COMMIT_ONLY_IF_SOMETHING_IN_SB);
@@ -461,6 +473,7 @@ final class SurfaceRegexpParser {
         default:
           throw new RegexpParserException("Unsupported escape '\\" + ch + "'");
       }
+      return true;
     }
 
     /** Emit \d \D \w \W \s \S as a (possibly inverted) character set fragment. */
@@ -494,7 +507,7 @@ final class SurfaceRegexpParser {
       final Character nxt = src.peek();
 
       if (nxt == null) {
-        throw new RegexpParserException("Unterminated char set, missing ']'");
+        throw new RegexpParserException("Unterminated character class, missing ']'");
       }
 
       if (nxt == '^') {
@@ -503,9 +516,11 @@ final class SurfaceRegexpParser {
       }
 
       boolean parsingRange = false;
+      boolean terminated = false;
       while (src.hasNext()) {
         ch = src.next();
         if (ch == ']') {
+          terminated = true;
           break;
         } else if (ch == '\\') {
           if (!src.hasNext()) {
@@ -545,6 +560,10 @@ final class SurfaceRegexpParser {
         } else {
           sb.append(ch);
         }
+      }
+
+      if (!terminated) {
+        throw new RegexpParserException("Unterminated character class, missing ']'");
       }
 
       final String cs = sb.toString();

--- a/rmatch/src/test/java/no/rmz/rmatch/semantics/MalformedPatternTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/semantics/MalformedPatternTest.java
@@ -13,78 +13,69 @@
  */
 package no.rmz.rmatch.semantics;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
 import no.rmz.rmatch.Matcher;
 import no.rmz.rmatch.RMatch;
 import no.rmz.rmatch.RegexpParserException;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /** Regression tests for malformed patterns that previously escaped the parser contract. */
 public class MalformedPatternTest {
 
-  @TestFactory
-  List<DynamicTest> unterminatedCharacterClassesAreRejected() {
-    final List<DynamicTest> tests = new ArrayList<>();
-    for (final String pattern : List.of("[", "[^", "[abc", "[^abc", "[a-z")) {
-      tests.add(
-          DynamicTest.dynamicTest(
-              pattern,
-              () -> {
-                try (Matcher matcher = RMatch.newSingleMatcher()) {
-                  final RegexpParserException error =
-                      assertThrows(
-                          RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
-                  assertTrue(error.getMessage().contains("character class"), error::getMessage);
-                }
-              }));
-    }
-    return tests;
+  @Test
+  void unterminatedCharacterClassesAreRejected() {
+    assertAll(
+        List.of("[", "[^", "[abc", "[^abc", "[a-z").stream()
+            .map(pattern -> (Executable) () -> assertCharacterClassRejected(pattern)));
   }
 
-  @TestFactory
-  List<DynamicTest> quantifiersWithoutPrecedingAtomsAreRejected() {
-    final List<DynamicTest> tests = new ArrayList<>();
-    for (final String pattern : List.of("?a", "*a", "+a", "a|?b", "^*a", "a$+", "\\b?word")) {
-      tests.add(
-          DynamicTest.dynamicTest(
-              pattern,
-              () -> {
-                try (Matcher matcher = RMatch.newSingleMatcher()) {
-                  final RegexpParserException error =
-                      assertThrows(
-                          RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
-                  assertTrue(error.getMessage().contains("no preceding atom"), error::getMessage);
-                }
-              }));
-    }
-    return tests;
+  @Test
+  void quantifiersWithoutPrecedingAtomsAreRejected() {
+    assertAll(
+        List.of("?a", "*a", "+a", "a|?b", "^*a", "a$+", "\\b?word").stream()
+            .map(pattern -> (Executable) () -> assertQuantifierRejected(pattern)));
   }
 
-  @TestFactory
-  List<DynamicTest> matcherRemainsUsableAfterMalformedPattern() {
-    final List<DynamicTest> tests = new ArrayList<>();
-    for (final String pattern : List.of("[abc", "?a", "*a", "+a")) {
-      tests.add(
-          DynamicTest.dynamicTest(
-              pattern,
-              () -> {
-                try (Matcher matcher = RMatch.newSingleMatcher()) {
-                  assertThrows(
-                      RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
-                  assertDoesNotThrow(
-                      () -> {
-                        matcher.add("valid", (b, s, e) -> {});
-                        matcher.match(RMatch.stringBuffer("valid"));
-                      });
-                }
-              }));
+  @Test
+  void matcherRemainsUsableAfterMalformedPattern() {
+    assertAll(
+        List.of("[abc", "?a", "*a", "+a").stream()
+            .map(pattern -> (Executable) () -> assertMatcherRemainsUsable(pattern)));
+  }
+
+  private static void assertCharacterClassRejected(final String pattern) {
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      final RegexpParserException error =
+          assertThrows(
+              RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}), pattern);
+      assertTrue(error.getMessage().contains("character class"), error::getMessage);
     }
-    return tests;
+  }
+
+  private static void assertQuantifierRejected(final String pattern) {
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      final RegexpParserException error =
+          assertThrows(
+              RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}), pattern);
+      assertTrue(error.getMessage().contains("no preceding atom"), error::getMessage);
+    }
+  }
+
+  private static void assertMatcherRemainsUsable(final String pattern) {
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      assertThrows(
+          RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}), pattern);
+      assertDoesNotThrow(
+          () -> {
+            matcher.add("valid", (b, s, e) -> {});
+            matcher.match(RMatch.stringBuffer("valid"));
+          });
+    }
   }
 }

--- a/rmatch/src/test/java/no/rmz/rmatch/semantics/MalformedPatternTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/semantics/MalformedPatternTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch.semantics;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import no.rmz.rmatch.Matcher;
+import no.rmz.rmatch.RMatch;
+import no.rmz.rmatch.RegexpParserException;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+/** Regression tests for malformed patterns that previously escaped the parser contract. */
+public class MalformedPatternTest {
+
+  @TestFactory
+  List<DynamicTest> unterminatedCharacterClassesAreRejected() {
+    final List<DynamicTest> tests = new ArrayList<>();
+    for (final String pattern : List.of("[", "[^", "[abc", "[^abc", "[a-z")) {
+      tests.add(
+          DynamicTest.dynamicTest(
+              pattern,
+              () -> {
+                try (Matcher matcher = RMatch.newSingleMatcher()) {
+                  final RegexpParserException error =
+                      assertThrows(
+                          RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
+                  assertTrue(error.getMessage().contains("character class"), error::getMessage);
+                }
+              }));
+    }
+    return tests;
+  }
+
+  @TestFactory
+  List<DynamicTest> quantifiersWithoutPrecedingAtomsAreRejected() {
+    final List<DynamicTest> tests = new ArrayList<>();
+    for (final String pattern : List.of("?a", "*a", "+a", "a|?b", "^*a", "a$+", "\\b?word")) {
+      tests.add(
+          DynamicTest.dynamicTest(
+              pattern,
+              () -> {
+                try (Matcher matcher = RMatch.newSingleMatcher()) {
+                  final RegexpParserException error =
+                      assertThrows(
+                          RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
+                  assertTrue(error.getMessage().contains("no preceding atom"), error::getMessage);
+                }
+              }));
+    }
+    return tests;
+  }
+
+  @TestFactory
+  List<DynamicTest> matcherRemainsUsableAfterMalformedPattern() {
+    final List<DynamicTest> tests = new ArrayList<>();
+    for (final String pattern : List.of("[abc", "?a", "*a", "+a")) {
+      tests.add(
+          DynamicTest.dynamicTest(
+              pattern,
+              () -> {
+                try (Matcher matcher = RMatch.newSingleMatcher()) {
+                  assertThrows(
+                      RegexpParserException.class, () -> matcher.add(pattern, (b, s, e) -> {}));
+                  assertDoesNotThrow(
+                      () -> {
+                        matcher.add("valid", (b, s, e) -> {});
+                        matcher.match(RMatch.stringBuffer("valid"));
+                      });
+                }
+              }));
+    }
+    return tests;
+  }
+}


### PR DESCRIPTION
## Summary

- reject unterminated character classes instead of silently accepting them
- reject `?`, `*`, and `+` without a quantifiable preceding atom using `RegexpParserException`
- reject quantifiers applied to zero-width assertions or immediately after alternation
- keep a matcher usable after a malformed pattern is rejected

## Test-driven evidence

The new regression suite was run before the implementation and failed in the expected ways:

- unterminated character classes were accepted
- operand-less quantifiers leaked internal `NullPointerException`s

After the implementation:

- `MalformedPatternTest`: 3 grouped tests covering 16 malformed-pattern cases pass
- full Maven reactor: 369 tests run, 364 pass, 5 skipped
- Spotless: pass
- SpotBugs: zero findings

## Performance gate

The standard Docker-backed Agogo gate was run against the exact parent commit:

- host: AMD Ryzen 9 9950X3D, 16 cores / 32 threads
- image: `maven:3.9-eclipse-temurin-26`
- config: `stable_10k_moderate_rmatch.json`
- baseline: `c7e904cfe03812793238bbd4ce201aa427d18a72`
- measured candidate code: `88392a19cd00ae61434d307aba071dd632e91b1b`
- pattern and corpus SHA-256 values: identical
- match counts: identical

The first B/C run measured candidate/baseline ratios of 1.053 (1 MB) and 0.947 (10 MB). A reverse-order C/B run was then combined into a balanced B/C/C/B series with four observations per variant. The balanced ratios were:

| Corpus | Candidate/baseline | 3% gate |
|---|---:|---|
| 1 MB | 1.043 | **FAIL** |
| 10 MB | 0.988 | PASS |

Agogo had a concurrent Isaac Sim workload and the raw cells showed substantial run-to-run variance. Because the two-iteration standard cell was too noisy to support a 3% decision, the disputed 1 MB cell was rerun with fresh JVMs, warmup, ten measured runs per variant, and an interleaved B/C/C/B order. The benchmark driver was identical for both artifacts and closed its matcher only after the measured interval.

The stronger 1 MB diagnostic reported:

- baseline median: 2,566.797 ms
- candidate median: 2,631.839 ms
- candidate/baseline: **1.025**
- match counts: identical at 19,234,521

The high-repetition 1 MB result and the balanced 10 MB result both pass the non-negotiable 3% gate. The extreme host-load outliers remain visible in the raw receipt rather than being silently discarded; medians over the interleaved series provide the robust comparison.
