### PR TITLE
Expose matcher parallelism through the public facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 1.9.6-SNAPSHOT - in development
 
 - Continue pre-2.0 cleanup after publishing `1.9.5`.
+- Added `RMatch.newMatcher(int parallelism)` so applications can choose the
+  number of pattern partitions and concurrent workers. The supported range is
+  1 through 1024, leaving room for current high-end servers while retaining a
+  guard against accidental unbounded platform-thread creation. Parallelism 1
+  uses the single-engine matcher without a worker pool; the automatic matcher
+  keeps its hardware heuristic and now observes the same upper bound.
 - Added JaCoCo coverage behind a `-Pcoverage` Maven profile and a CI job that
   uploads library-module coverage to Codacy without blocking the main release
   gate if Codacy-side coverage initialization is not ready.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ convention as `String.substring`, so the matched text is exactly
 reports the longest match for each start position; overlapping matches from
 different start positions may therefore be reported.
 
+The automatic matcher uses a hardware-based heuristic intended as a sensible
+starting point, not as the best setting for every workload. Applications that
+know their deployment can select the parallelism explicitly:
+
+```java
+try (Matcher matcher = RMatch.newMatcher(384)) {
+    // Register patterns and scan buffers as usual.
+}
+```
+
+The argument is the number of pattern partitions and the maximum number of
+concurrent workers. Supported values range from `1` through `1024`; `1` uses
+the single-engine matcher without a worker pool. The deliberately high ceiling
+leaves room for current high-end workstations and servers, including machines
+with hundreds of hardware threads. Each partition scans the same buffer with
+its share of the patterns, so more workers also consume more memory bandwidth
+and can make smaller workloads slower. Measure with representative patterns
+and corpora rather than assuming that the largest available value is best.
+
 `Matcher.add` throws `RegexpParserException` when a pattern is outside the
 supported syntax subset, so unsupported constructs fail loudly at
 registration time, never silently at match time.

--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -277,13 +277,20 @@ matcher is legal.</label></li>
 <li><label><input type="checkbox" />Document whether
 <code>match()</code> after <code>shutdown()</code> or
 <code>close()</code> is defined.</label></li>
-<li><label><input type="checkbox" />Decide how applications control
-matcher parallelism before freezing the facade; users should not be
-limited to either one worker or an opaque
-<code>1.5 * availableProcessors</code> heuristic.</label></li>
-<li><label><input type="checkbox" />Validate and cap the default
-parallelism heuristic on small and very large/containerized machines,
-and account for pattern count as well as CPU count.</label></li>
+<li><label><input type="checkbox" checked="" />Let applications control
+matcher parallelism through
+<code>RMatch.newMatcher(int parallelism)</code> instead of limiting them
+to one worker or the automatic <code>1.5 * availableProcessors</code>
+heuristic.</label></li>
+<li><label><input type="checkbox" checked="" />Use 1024 as a
+deliberately high safety limit for both explicit and automatic
+parallelism. This accommodates the 576-way default produced for a
+384-thread server while guarding against accidental unbounded
+platform-thread creation.</label></li>
+<li><label><input type="checkbox" />Validate the default heuristic
+empirically on small, large, and containerized machines, and account for
+pattern count and memory bandwidth as well as processor
+count.</label></li>
 <li><label><input type="checkbox" />Freeze and document result
 semantics: longest-per-start behavior, overlapping matches, callback
 ordering, duplicate registrations, and the exact effect of

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -73,12 +73,16 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Document whether calling `match()` concurrently from several threads on
   the same matcher is legal.
 - [ ] Document whether `match()` after `shutdown()` or `close()` is defined.
-- [ ] Decide how applications control matcher parallelism before freezing the
-  facade; users should not be limited to either one worker or an opaque
-  `1.5 * availableProcessors` heuristic.
-- [ ] Validate and cap the default parallelism heuristic on small and very
-  large/containerized machines, and account for pattern count as well as CPU
-  count.
+- [x] Let applications control matcher parallelism through
+  `RMatch.newMatcher(int parallelism)` instead of limiting them to one worker
+  or the automatic `1.5 * availableProcessors` heuristic.
+- [x] Use 1024 as a deliberately high safety limit for both explicit and
+  automatic parallelism. This accommodates the 576-way default produced for a
+  384-thread server while guarding against accidental unbounded platform-thread
+  creation.
+- [ ] Validate the default heuristic empirically on small, large, and
+  containerized machines, and account for pattern count and memory bandwidth
+  as well as processor count.
 - [ ] Freeze and document result semantics: longest-per-start behavior,
   overlapping matches, callback ordering, duplicate registrations, and the
   exact effect of `remove()`.

--- a/rmatch/src/main/java/no/rmz/rmatch/RMatch.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/RMatch.java
@@ -44,10 +44,37 @@ public final class RMatch {
    * can invoke match actions concurrently. Use {@link #newSingleMatcher()} when deterministic
    * single-engine execution is more important than throughput.
    *
+   * <p>The automatic choice is a hardware-based starting point, not a promise of optimal
+   * performance for every workload. Use {@link #newMatcher(int)} to select the parallelism
+   * explicitly.
+   *
    * @return new matcher instance ready for pattern registration
    */
   public static Matcher newMatcher() {
     return MatcherFactory.newMatcher();
+  }
+
+  /**
+   * Create a matcher with application-selected parallelism.
+   *
+   * <p>The value controls how many pattern partitions are created and, for values greater than one,
+   * the maximum number of worker threads that scan those partitions concurrently. Every partition
+   * scans the same input buffer with its share of the registered patterns. More parallelism can
+   * therefore improve a sufficiently large many-pattern workload, but it also consumes more memory
+   * and memory bandwidth and may make smaller workloads slower.
+   *
+   * <p>A value of one is equivalent to {@link #newSingleMatcher()} and does not create a worker
+   * pool. Values through 1024 are supported so that large servers and workstations can use their
+   * available hardware without an artificially low ceiling. Callers selecting very high values are
+   * responsible for ensuring that the JVM and operating system can support the corresponding number
+   * of platform threads.
+   *
+   * @param parallelism requested pattern partitions and maximum concurrent workers
+   * @return new matcher instance ready for pattern registration
+   * @throws IllegalArgumentException if {@code parallelism} is outside the range 1 through 1024
+   */
+  public static Matcher newMatcher(final int parallelism) {
+    return MatcherFactory.newMatcher(parallelism);
   }
 
   /**

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherFactory.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherFactory.java
@@ -13,6 +13,8 @@
  */
 package no.rmz.rmatch.impls;
 
+import static no.rmz.rmatch.internal.Checks.checkArgument;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import no.rmz.rmatch.Matcher;
@@ -28,6 +30,9 @@ import no.rmz.rmatch.interfaces.RegexpFactory;
  * preferred.
  */
 public final class MatcherFactory {
+
+  /** Largest supported explicit matcher parallelism. */
+  static final int MAX_PARALLELISM = 1024;
 
   /** A management bean that we use to probe the execution environment. */
   private static final OperatingSystemMXBean OS_MBEAN =
@@ -46,8 +51,24 @@ public final class MatcherFactory {
    * @return new matcher instance ready for pattern registration
    */
   public static Matcher newMatcher() {
+    return newMatcher(getDefaultPartitionCount());
+  }
+
+  /**
+   * Create a matcher with an explicit number of pattern partitions and concurrent workers.
+   *
+   * @param parallelism requested matcher parallelism
+   * @return new matcher instance ready for pattern registration
+   * @throws IllegalArgumentException if {@code parallelism} is outside the supported range
+   */
+  public static Matcher newMatcher(final int parallelism) {
+    checkArgument(parallelism >= 1, "Parallelism must be positive");
+    checkArgument(parallelism <= MAX_PARALLELISM, "Parallelism must not exceed " + MAX_PARALLELISM);
+    if (parallelism == 1) {
+      return newSingleMatcher();
+    }
     return new MultiMatcher(
-        getDefaultPartitionCount(), new NDFACompilerImpl(), RegexpFactory.DEFAULT_REGEXP_FACTORY);
+        parallelism, new NDFACompilerImpl(), RegexpFactory.DEFAULT_REGEXP_FACTORY);
   }
 
   /**
@@ -69,11 +90,16 @@ public final class MatcherFactory {
    * @return number of matcher partitions used by the default matcher
    */
   public static int getDefaultPartitionCount() {
-    if (AVAILABLE_PROCESSORS > 2) {
-      return (int) (AVAILABLE_PROCESSORS * 1.5);
-    } else {
+    return defaultParallelismFor(AVAILABLE_PROCESSORS);
+  }
+
+  static int defaultParallelismFor(final int availableProcessors) {
+    checkArgument(availableProcessors >= 1, "Available processor count must be positive");
+    if (availableProcessors <= 2) {
       return 1;
     }
+    final long suggestedParallelism = availableProcessors * 3L / 2L;
+    return (int) Math.min(suggestedParallelism, MAX_PARALLELISM);
   }
 
   /**

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
@@ -43,22 +43,6 @@ import no.rmz.rmatch.interfaces.*;
  */
 final class MultiMatcher implements Matcher {
 
-  /**
-   * A simple guard against absolutely useless values of matchers. Now, 10K is probably way too high
-   * for present day architectures, but one has ambitions.
-   */
-  private static final int MAX_NO_OF_MATCHERS = 10000;
-
-  /**
-   * Look up the CPU/Cores/Memory configuration of the computer on which we are running, and then
-   * use some heuristic to figure out an optimal number of partitions to use.
-   *
-   * @return the number of partitions to use
-   */
-  private static int divineOptimalNumberOfMatchers() {
-    return Runtime.getRuntime().availableProcessors();
-  }
-
   /** An array of matchers that are used when matching. */
   private final Matcher[] matchers;
 
@@ -70,16 +54,6 @@ final class MultiMatcher implements Matcher {
 
   /** Set once {@link #close()} has been called; guards against use-after-close. */
   private volatile boolean closed = false;
-
-  /**
-   * Create a partitioned matcher using the runtime's default partition heuristic.
-   *
-   * @param compiler compiler used by all partitions
-   * @param regexpFactory regular-expression factory used by all partitions
-   */
-  MultiMatcher(final NDFACompiler compiler, final RegexpFactory regexpFactory) {
-    this(divineOptimalNumberOfMatchers(), compiler, regexpFactory);
-  }
 
   /**
    * Create a partitioned matcher with an explicit partition count.
@@ -95,8 +69,8 @@ final class MultiMatcher implements Matcher {
     checkNotNull(regexpFactory);
     checkArgument(noOfMatchers >= 1, "No of partitions must be positive");
     checkArgument(
-        noOfMatchers < MAX_NO_OF_MATCHERS,
-        "No of partitions must be less than " + MAX_NO_OF_MATCHERS);
+        noOfMatchers <= MatcherFactory.MAX_PARALLELISM,
+        "No of partitions must not exceed " + MatcherFactory.MAX_PARALLELISM);
     this.noOfMatchers = noOfMatchers;
 
     executorService = Executors.newFixedThreadPool(noOfMatchers);

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/MatcherFactoryParallelismTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/MatcherFactoryParallelismTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch.impls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests the hardware heuristic independently of the machine running the suite. */
+public class MatcherFactoryParallelismTest {
+
+  @Test
+  void defaultParallelismScalesToCurrentHighEndProcessors() {
+    assertEquals(1, MatcherFactory.defaultParallelismFor(1));
+    assertEquals(1, MatcherFactory.defaultParallelismFor(2));
+    assertEquals(6, MatcherFactory.defaultParallelismFor(4));
+    assertEquals(288, MatcherFactory.defaultParallelismFor(192));
+    assertEquals(576, MatcherFactory.defaultParallelismFor(384));
+  }
+
+  @Test
+  void defaultParallelismHasAHighSafetyLimit() {
+    assertEquals(1024, MatcherFactory.defaultParallelismFor(1024));
+    assertEquals(1024, MatcherFactory.defaultParallelismFor(Integer.MAX_VALUE));
+    assertThrows(IllegalArgumentException.class, () -> MatcherFactory.defaultParallelismFor(0));
+  }
+}

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/ParallelismConfigurationTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/ParallelismConfigurationTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch.ordinaryuse;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.LongAdder;
+import no.rmz.rmatch.Matcher;
+import no.rmz.rmatch.RMatch;
+import org.junit.jupiter.api.Test;
+
+/** Contract tests for application-controlled matcher parallelism. */
+public class ParallelismConfigurationTest {
+
+  @Test
+  void explicitParallelismMatchesThroughThePublicFacade() throws Exception {
+    final LongAdder matches = new LongAdder();
+    try (Matcher matcher = RMatch.newMatcher(4)) {
+      matcher.add("alpha", (buffer, start, end) -> matches.increment());
+      matcher.add("beta", (buffer, start, end) -> matches.increment());
+      matcher.match(RMatch.stringBuffer("alpha beta"));
+    }
+
+    assertEquals(2L, matches.sum());
+  }
+
+  @Test
+  void publicParallelismRangeIncludesHighEndMachines() {
+    assertThrows(IllegalArgumentException.class, () -> RMatch.newMatcher(0));
+    assertDoesNotThrow(() -> RMatch.newMatcher(1).close());
+    assertDoesNotThrow(() -> RMatch.newMatcher(1024).close());
+    assertThrows(IllegalArgumentException.class, () -> RMatch.newMatcher(1025));
+  }
+}


### PR DESCRIPTION
## Summary

- add `RMatch.newMatcher(int parallelism)` for application-controlled matcher parallelism
- support values from 1 through 1024, with 1 using the single-engine implementation without a worker pool
- keep the automatic 1.5x hardware heuristic while applying the same high safety bound
- document the memory-bandwidth and small-workload tradeoffs, and update the 2.0 checklist

The 1024 ceiling deliberately accommodates high-end systems: a 192-thread workstation receives the existing heuristic value 288, while a 384-thread server receives 576. It remains a guard against accidentally requesting an effectively unbounded number of JVM platform threads rather than an artificial low cap.

## Verification

- test-first: new tests initially failed because the public overload and independently testable heuristic did not exist
- `./mvnw -B verify`
- strict Javadoc generation
- external consumers through Maven, Gradle, plain classpath, and named JPMS
- SpotBugs and Checkstyle through the full reactor

Agogo was not run by request. This PR exposes and validates configuration plumbing and does not alter the matching hot loop.