### PR TITLE
Freeze matcher registrations before scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
   guard against accidental unbounded platform-thread creation. Parallelism 1
   uses the single-engine matcher without a worker pool; the automatic matcher
   keeps its hardware heuristic and now observes the same upper bound.
+- BREAKING (2.0 contract): matchers now have an explicit build-then-use
+  lifecycle. The first `match()` permanently freezes pattern registration;
+  later `add()` calls throw `IllegalStateException`. The experimental
+  `remove()` methods have been removed from the public and internal matcher
+  contracts. Applications with a changed rule set construct a replacement
+  matcher instead of mutating compiled automata.
+- Pattern/action registration now uses action object identity. Re-registering
+  the same action instance for one pattern is idempotent, while distinct action
+  instances remain distinct even when `equals()` considers them equal.
+  Callback order is explicitly unspecified for both single and partitioned
+  matchers.
 - Added JaCoCo coverage behind a `-Pcoverage` Maven profile and a CI job that
   uploads library-module coverage to Codacy without blocking the main release
   gate if Codacy-side coverage initialization is not ready.

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ Run it:
 mvn -q compile exec:java -Dexec.mainClass=Example
 ```
 
-Expected output contains both lines. The order may vary because
-`RMatch.newMatcher()` may use worker threads:
+Expected output contains both lines. Callback order is deliberately
+unspecified, even for a single-engine matcher; the production matcher may also
+invoke actions concurrently:
 
 ```text
 user token match: user:alice
@@ -176,6 +177,14 @@ convention as `String.substring`, so the matched text is exactly
 `buffer.getString(start, end)` and its length is `end - start`. rmatch
 reports the longest match for each start position; overlapping matches from
 different start positions may therefore be reported.
+
+A matcher has a build-then-use lifecycle. Register every pattern before the
+first call to `match()`; that first scan permanently freezes registration.
+Create a replacement matcher when the rule set changes. Registering the same
+`Action` object more than once for one pattern is idempotent. Two distinct
+action objects remain distinct even if their `equals()` methods consider them
+equal, and both are invoked for each reported match. If result order matters,
+collect the callbacks and sort them explicitly.
 
 The automatic matcher uses a hardware-based heuristic intended as a sensible
 starting point, not as the best setting for every workload. Applications that
@@ -215,7 +224,7 @@ for (Rule rule : rules) {
 
 Actions may run concurrently on a partitioned matcher, so collect into a
 thread-safe structure (`LongAdder`, a concurrent collection, or a
-synchronized block).
+synchronized block). No callback order is guaranteed.
 
 For one small pattern against one small string, `java.util.regex` is usually the
 simpler tool. rmatch is for many-pattern workloads where avoiding a separate

--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -268,15 +268,18 @@ explicit type.</label></li>
 <li><label><input type="checkbox" />Document whether one throwing action
 aborts the scan immediately or after already-started partitions
 finish.</label></li>
-<li><label><input type="checkbox" />Document whether <code>add()</code>
-or <code>remove()</code> during an in-flight <code>match()</code> is
-legal.</label></li>
-<li><label><input type="checkbox" />Document whether calling
+<li><label><input type="checkbox" checked="" />Adopt and document a
+build-then-use matcher lifecycle: the first <code>match()</code> freezes
+registration and later <code>add()</code> calls fail.</label></li>
+<li><label><input type="checkbox" checked="" />Remove the experimental
+<code>remove()</code> API rather than promising mutation of compiled
+automata that retain stale graph and cache state.</label></li>
+<li><label><input type="checkbox" checked="" />Document that calling
 <code>match()</code> concurrently from several threads on the same
-matcher is legal.</label></li>
-<li><label><input type="checkbox" />Document whether
-<code>match()</code> after <code>shutdown()</code> or
-<code>close()</code> is defined.</label></li>
+matcher is not supported.</label></li>
+<li><label><input type="checkbox" checked="" />Document that
+<code>match()</code> and <code>add()</code> after <code>close()</code>
+fail, while <code>close()</code> remains idempotent.</label></li>
 <li><label><input type="checkbox" checked="" />Let applications control
 matcher parallelism through
 <code>RMatch.newMatcher(int parallelism)</code> instead of limiting them
@@ -291,10 +294,17 @@ platform-thread creation.</label></li>
 empirically on small, large, and containerized machines, and account for
 pattern count and memory bandwidth as well as processor
 count.</label></li>
-<li><label><input type="checkbox" />Freeze and document result
+<li><label><input type="checkbox" checked="" />Define callback
+registration by action object identity: duplicate registration of the
+same instance is idempotent, while distinct instances remain distinct
+regardless of <code>equals()</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Specify that callback
+ordering is not guaranteed, including with a single-engine
+matcher.</label></li>
+<li><label><input type="checkbox" />Freeze and document remaining result
 semantics: longest-per-start behavior, overlapping matches, callback
-ordering, duplicate registrations, and the exact effect of
-<code>remove()</code>.</label></li>
+multiplicity across patterns, and duplicate pattern text with different
+flags.</label></li>
 <li><label><input type="checkbox" />Ensure parser failures identify the
 unsupported or malformed construct and its location well enough for a
 user to repair a large generated pattern.</label></li>
@@ -651,8 +661,9 @@ syntax-and-semantics reference separate from the README, including
 character/Unicode rules, match selection, exclusions, and
 examples.</label></li>
 <li><label><input type="checkbox" />Include package flattening, removed
-aliases, callback-offset decisions, lifecycle changes, and buffer helper
-changes in the migration guide.</label></li>
+aliases and <code>remove()</code>, callback-offset decisions,
+build-then-use lifecycle changes, and buffer helper changes in the
+migration guide.</label></li>
 <li><label><input type="checkbox" />Add or update
 <code>CONTRIBUTING.md</code> with build, test, benchmark, and PR
 expectations.</label></li>

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -68,11 +68,14 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Document what happens when an `Action` throws during matching.
 - [ ] Document whether one throwing action aborts the scan immediately or after
   already-started partitions finish.
-- [ ] Document whether `add()` or `remove()` during an in-flight `match()` is
-  legal.
-- [ ] Document whether calling `match()` concurrently from several threads on
-  the same matcher is legal.
-- [ ] Document whether `match()` after `shutdown()` or `close()` is defined.
+- [x] Adopt and document a build-then-use matcher lifecycle: the first
+  `match()` freezes registration and later `add()` calls fail.
+- [x] Remove the experimental `remove()` API rather than promising mutation of
+  compiled automata that retain stale graph and cache state.
+- [x] Document that calling `match()` concurrently from several threads on the
+  same matcher is not supported.
+- [x] Document that `match()` and `add()` after `close()` fail, while `close()`
+  remains idempotent.
 - [x] Let applications control matcher parallelism through
   `RMatch.newMatcher(int parallelism)` instead of limiting them to one worker
   or the automatic `1.5 * availableProcessors` heuristic.
@@ -83,9 +86,14 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Validate the default heuristic empirically on small, large, and
   containerized machines, and account for pattern count and memory bandwidth
   as well as processor count.
-- [ ] Freeze and document result semantics: longest-per-start behavior,
-  overlapping matches, callback ordering, duplicate registrations, and the
-  exact effect of `remove()`.
+- [x] Define callback registration by action object identity: duplicate
+  registration of the same instance is idempotent, while distinct instances
+  remain distinct regardless of `equals()`.
+- [x] Specify that callback ordering is not guaranteed, including with a
+  single-engine matcher.
+- [ ] Freeze and document remaining result semantics: longest-per-start
+  behavior, overlapping matches, callback multiplicity across patterns, and
+  duplicate pattern text with different flags.
 - [ ] Ensure parser failures identify the unsupported or malformed construct
   and its location well enough for a user to repair a large generated pattern.
 
@@ -325,8 +333,9 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Add a clear `1.x` to `2.0` migration section in `CHANGELOG.md`.
 - [ ] Publish a stable syntax-and-semantics reference separate from the README,
   including character/Unicode rules, match selection, exclusions, and examples.
-- [ ] Include package flattening, removed aliases, callback-offset decisions,
-  lifecycle changes, and buffer helper changes in the migration guide.
+- [ ] Include package flattening, removed aliases and `remove()`, callback-offset
+  decisions, build-then-use lifecycle changes, and buffer helper changes in
+  the migration guide.
 - [ ] Add or update `CONTRIBUTING.md` with build, test, benchmark, and PR
   expectations.
 - [ ] Add or update `SECURITY.md` with a vulnerability-reporting channel.

--- a/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/JavaRegexpMatcher.java
+++ b/rmatch-tester/src/main/java/no/rmz/rmatch/performancetests/JavaRegexpMatcher.java
@@ -42,7 +42,7 @@ public class JavaRegexpMatcher implements Matcher {
    * A map that for all the actions we are managing, keeps track of all the regexps that are
    * triggered by that particular action.
    */
-  private final Map<Action, Set<String>> actionToRegexpMap = new HashMap<>();
+  private final Map<Action, Set<String>> actionToRegexpMap = new IdentityHashMap<>(1);
 
   /** A collector of worker processes that should be used when running the matches. */
   private final Collection<Callable<Object>> matchers = new LinkedList<>();
@@ -57,7 +57,7 @@ public class JavaRegexpMatcher implements Matcher {
    * A state parameter for the class. When in matching state it is illegal to add more regexp/action
    * pairs.
    */
-  private final boolean matching = false;
+  private boolean matching = false;
 
   public JavaRegexpMatcher() {
     // Don't know what an optimal number is.  The heuristic
@@ -103,6 +103,7 @@ public class JavaRegexpMatcher implements Matcher {
 
   @Override
   public void match(final Buffer b) {
+    matching = true;
     makeMatchers(b, collectText(b));
     try {
       es.invokeAll(matchers);
@@ -138,11 +139,6 @@ public class JavaRegexpMatcher implements Matcher {
     final Set<String> targetSet = getSetForAction(actionToRun);
 
     targetSet.add(rexpString);
-  }
-
-  @Override
-  public void remove(String r, Action a) {
-    throw new UnsupportedOperationException("Not supported yet.");
   }
 
   @Override

--- a/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/Matcher.java
@@ -36,12 +36,15 @@ import java.util.Set;
  * Buffer#getString(long, long)}, so matched text is recovered with {@code buffer.getString(start,
  * end)}.
  *
- * <p><b>Threading contract:</b> a matcher instance is not a concurrent registry. Register patterns
- * first, then match; do not call {@link #add(String, Action)} or {@link #remove(String, Action)}
- * while a {@link #match(Buffer)} is in progress, and do not invoke {@link #match(Buffer)}
- * concurrently from several threads on the same instance. Alternating registration and matching
- * phases sequentially is fully supported. Partitioned implementations parallelize internally, so
- * callers rarely need concurrent access to the matcher object itself.
+ * <p><b>Registration contract:</b> register every pattern before the first call to {@link
+ * #match(Buffer)}. That first scan permanently freezes the matcher; later calls to {@link
+ * #add(String, Action)} throw {@link IllegalStateException}. Construct a replacement matcher when
+ * the rule set changes. This build-then-use lifecycle keeps compiled automata immutable while they
+ * are being reused.
+ *
+ * <p><b>Threading contract:</b> do not invoke {@link #match(Buffer)} concurrently from several
+ * threads on the same matcher. Partitioned implementations parallelize internally, so callers
+ * rarely need concurrent access to the matcher object itself.
  *
  * <p><b>Lifecycle contract:</b> after {@link #close()}, every method except {@code close()} throws
  * {@link IllegalStateException}. Closing is idempotent.
@@ -51,6 +54,11 @@ public interface Matcher extends AutoCloseable {
   /**
    * Register a regular expression and the action to invoke whenever that expression matches.
    *
+   * <p>Registration uses action object identity. Registering the same action instance for the same
+   * expression more than once has no additional effect; distinct action instances remain distinct
+   * even if their {@link Object#equals(Object)} methods say they are equal. Every registered action
+   * is invoked once for each reported match of its expression. Callback order is unspecified.
+   *
    * <p>The same action may be registered for more than one expression. Implementations may invoke
    * actions concurrently, so action implementations must be thread-safe unless the caller knows the
    * concrete matcher is single-threaded.
@@ -58,7 +66,7 @@ public interface Matcher extends AutoCloseable {
    * @param r regular-expression text in the rmatch supported syntax subset
    * @param a action to run for each match
    * @throws RegexpParserException if {@code r} cannot be parsed by the supported rmatch syntax
-   * @throws IllegalStateException if the matcher has been closed
+   * @throws IllegalStateException if matching has started or the matcher has been closed
    */
   void add(final String r, final Action a) throws RegexpParserException;
 
@@ -67,14 +75,13 @@ public interface Matcher extends AutoCloseable {
    *
    * <p>Flags express the same semantics as the corresponding inline syntax; for example {@link
    * PatternFlag#CASE_INSENSITIVE} is equivalent to prefixing the pattern with {@code (?i)}. The
-   * flagged registration is identified by the combination of pattern and flags, so a later {@link
-   * #remove(String, Set, Action)} must supply the same flags.
+   * flagged registration is identified by the combination of pattern and flags.
    *
    * @param r regular-expression text in the rmatch supported syntax subset
    * @param flags per-pattern option flags; an empty or {@code null} set means no flags
    * @param a action to run for each match
    * @throws RegexpParserException if {@code r} cannot be parsed by the supported rmatch syntax
-   * @throws IllegalStateException if the matcher has been closed
+   * @throws IllegalStateException if matching has started or the matcher has been closed
    */
   default void add(final String r, final Set<PatternFlag> flags, final Action a)
       throws RegexpParserException {
@@ -82,36 +89,15 @@ public interface Matcher extends AutoCloseable {
   }
 
   /**
-   * Remove one association between a regular expression and an action.
-   *
-   * <p>If the same expression has several actions, only the supplied expression/action pair is
-   * removed. Removing a pair that is not present is a no-op.
-   *
-   * @param r regular-expression text previously registered with {@link #add(String, Action)}
-   * @param a action previously associated with {@code r}
-   * @throws IllegalStateException if the matcher has been closed
-   */
-  void remove(final String r, final Action a);
-
-  /**
-   * Remove an expression/action pair that was registered with flags.
-   *
-   * <p>The flags must equal the flags used at registration time.
-   *
-   * @param r regular-expression text previously registered with {@link #add(String, Set, Action)}
-   * @param flags flags supplied when the pair was registered
-   * @param a action previously associated with {@code r}
-   * @throws IllegalStateException if the matcher has been closed
-   */
-  default void remove(final String r, final Set<PatternFlag> flags, final Action a) {
-    remove(PatternFlag.applyTo(r, flags), a);
-  }
-
-  /**
    * Scan the supplied buffer with all currently registered expressions.
    *
    * <p>Actions are invoked during the scan. Match callbacks receive the same buffer instance plus
-   * half-open {@code [start, end)} offsets for the matched text.
+   * half-open {@code [start, end)} offsets for the matched text. No ordering is guaranteed between
+   * callbacks, including callbacks from a single-engine matcher; collect and sort results when
+   * order matters.
+   *
+   * <p>The first call permanently freezes pattern registration, even if the buffer is empty or the
+   * scan fails.
    *
    * <p>An exception thrown by an action is not swallowed: it aborts that scan and propagates out of
    * this method, so remaining matches in the aborted scan are not reported. In a partitioned

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherImpl.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MatcherImpl.java
@@ -60,6 +60,9 @@ final class MatcherImpl implements Matcher {
   /** Set once {@link #close()} has been called; guards against use-after-close. */
   private volatile boolean closed = false;
 
+  /** Set by the first scan; compiled registrations are immutable from that point onward. */
+  private volatile boolean registrationFrozen = false;
+
   /** Create a new matcher using the default compiler, regexp factory, and engine selection. */
   MatcherImpl() {
     this(new NDFACompilerImpl(), RegexpFactory.DEFAULT_REGEXP_FACTORY);
@@ -98,23 +101,9 @@ final class MatcherImpl implements Matcher {
   @Override
   public void add(final String r, final Action a) throws RegexpParserException {
     ensureOpen();
+    ensureRegistrationOpen();
     synchronized (rs) {
       rs.add(r, a);
-      prefilterDirty = true;
-    }
-  }
-
-  /**
-   * Remove an expression/action pair from this matcher.
-   *
-   * @param r regular-expression text previously registered with this matcher
-   * @param a action previously associated with {@code r}
-   */
-  @Override
-  public void remove(final String r, final Action a) {
-    ensureOpen();
-    synchronized (rs) {
-      rs.remove(r, a);
       prefilterDirty = true;
     }
   }
@@ -186,6 +175,7 @@ final class MatcherImpl implements Matcher {
   @Override
   public void match(final Buffer b) {
     ensureOpen();
+    registrationFrozen = true;
     ensurePrefilterConfigured();
 
     synchronized (me) {
@@ -205,9 +195,15 @@ final class MatcherImpl implements Matcher {
     }
   }
 
+  private void ensureRegistrationOpen() {
+    if (registrationFrozen) {
+      throw new IllegalStateException("Matcher registrations are frozen after the first match");
+    }
+  }
+
   /**
    * Configure engine-specific prefilters on-demand. This avoids rebuilding heavy data structures
-   * for every single addition/removal when callers batch pattern registration.
+   * for every addition while callers assemble the pattern set before the first scan.
    */
   private void ensurePrefilterConfigured() {
     if (!prefilterDirty) {

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/MultiMatcher.java
@@ -55,6 +55,9 @@ final class MultiMatcher implements Matcher {
   /** Set once {@link #close()} has been called; guards against use-after-close. */
   private volatile boolean closed = false;
 
+  /** Set by the first scan; no partition accepts later registrations. */
+  private volatile boolean registrationFrozen = false;
+
   /**
    * Create a partitioned matcher with an explicit partition count.
    *
@@ -107,19 +110,8 @@ final class MultiMatcher implements Matcher {
   @Override
   public void add(final String r, final Action a) throws RegexpParserException {
     ensureOpen();
+    ensureRegistrationOpen();
     getMatcher(r).add(r, a);
-  }
-
-  /**
-   * Remove an expression/action pair from its partition.
-   *
-   * @param r regular-expression text previously registered with this matcher
-   * @param a action previously associated with {@code r}
-   */
-  @Override
-  public void remove(final String r, final Action a) {
-    ensureOpen();
-    getMatcher(r).remove(r, a);
   }
 
   /**
@@ -133,6 +125,7 @@ final class MultiMatcher implements Matcher {
   @Override
   public void match(final Buffer b) {
     ensureOpen();
+    registrationFrozen = true;
     assert (matchers.length == noOfMatchers);
 
     final CountDownLatch counter = new CountDownLatch(matchers.length);
@@ -177,6 +170,12 @@ final class MultiMatcher implements Matcher {
   private void ensureOpen() {
     if (closed) {
       throw new IllegalStateException("Matcher is closed");
+    }
+  }
+
+  private void ensureRegistrationOpen() {
+    if (registrationFrozen) {
+      throw new IllegalStateException("Matcher registrations are frozen after the first match");
     }
   }
 

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/RegexpImpl.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/RegexpImpl.java
@@ -16,9 +16,11 @@ package no.rmz.rmatch.impls;
 import static no.rmz.rmatch.internal.Checks.checkArgument;
 import static no.rmz.rmatch.internal.Checks.checkNotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,10 +35,10 @@ public final class RegexpImpl implements Regexp {
   private final String rexpString;
 
   /**
-   * The set of actions associated with this regular expression. These actions will be invoked when
-   * a match for the regular expression is detected.
+   * Actions associated with this regular expression. Identity checks make repeated registration of
+   * the same callback instance idempotent without imposing hash-table overhead on the match path.
    */
-  private final Set<Action> actions = new HashSet<>();
+  private final List<Action> actions = new ArrayList<>(1);
 
   /**
    * The set of nodes that are currently involved in matching expressions for this regular
@@ -131,18 +133,12 @@ public final class RegexpImpl implements Regexp {
   @Override
   public void add(final Action a) {
     checkNotNull(a);
+    for (final Action registered : actions) {
+      if (registered == a) {
+        return;
+      }
+    }
     actions.add(a);
-  }
-
-  @Override
-  public void remove(final Action a) {
-    checkNotNull(a);
-    actions.remove(a);
-  }
-
-  @Override
-  public boolean hasActions() {
-    return !actions.isEmpty();
   }
 
   @Override

--- a/rmatch/src/main/java/no/rmz/rmatch/impls/RegexpStorageImpl.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/impls/RegexpStorageImpl.java
@@ -99,18 +99,6 @@ final class RegexpStorageImpl implements RegexpStorage {
   }
 
   @Override
-  public void remove(final String rexp, final Action a) {
-    synchronized (regexps) {
-      final Regexp r = getRegexp(rexp);
-
-      r.remove(a);
-      if (!r.hasActions()) {
-        regexps.remove(rexp);
-      }
-    }
-  }
-
-  @Override
   public Set<String> getRegexpSet() {
     synchronized (regexps) {
       return regexps.keySet();

--- a/rmatch/src/main/java/no/rmz/rmatch/interfaces/Regexp.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/interfaces/Regexp.java
@@ -86,16 +86,6 @@ public interface Regexp extends Comparable<Regexp> {
   String getRexpString();
 
   /**
-   * Return whether this expression has any registered actions.
-   *
-   * <p>An expression without actions has no observable application effect and can often be ignored
-   * by the matcher.
-   *
-   * @return {@code true} if at least one action is registered
-   */
-  boolean hasActions();
-
-  /**
    * Return whether this expression currently has active match candidates.
    *
    * @return {@code true} if one or more candidates are associated with this expression
@@ -163,13 +153,6 @@ public interface Regexp extends Comparable<Regexp> {
    * @param m match candidate to associate with this expression
    */
   void registerMatch(final Match m);
-
-  /**
-   * Remove an action from this regexp.
-   *
-   * @param a action to remove
-   */
-  void remove(final Action a);
 
   /**
    * Store the start node produced when this expression is compiled.

--- a/rmatch/src/main/java/no/rmz/rmatch/interfaces/RegexpStorage.java
+++ b/rmatch/src/main/java/no/rmz/rmatch/interfaces/RegexpStorage.java
@@ -52,14 +52,6 @@ public interface RegexpStorage {
   void add(final String regexp, final Action a) throws RegexpParserException;
 
   /**
-   * Remove one association between a regular expression and an action.
-   *
-   * @param regexp regular-expression text
-   * @param a action to remove from the expression
-   */
-  void remove(final String regexp, final Action a);
-
-  /**
    * Return the pattern strings known to this storage.
    *
    * @return stored regular-expression strings

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/RegexpImplTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/RegexpImplTest.java
@@ -116,29 +116,6 @@ public class RegexpImplTest {
     assertEquals(re.getRexpString(), reString);
   }
 
-  /** Test that the regexp has some actions after adding an action. */
-  @Test
-  public void testHasActions() {
-    assertFalse(re.hasActions());
-    re.add(a);
-    assertTrue(re.hasActions());
-  }
-
-  /** Check that adding an action doesn't fail. */
-  @Test
-  public void testAddAction() {
-    re.add(a);
-    assertTrue(re.hasActions());
-  }
-
-  /** Checking that removing an action works. */
-  @Test
-  public void testRemoveAction() {
-    testAddAction();
-    re.remove(a);
-    assertFalse(re.hasActions());
-  }
-
   /** Mock up a match to use when testing the match registration mechanism. */
   @Mock MatchSet matchSet;
 

--- a/rmatch/src/test/java/no/rmz/rmatch/impls/RegexpStorageTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/impls/RegexpStorageTest.java
@@ -82,14 +82,12 @@ public final class RegexpStorageTest {
     when(compiler.compile(any(), any())).thenReturn(compilationResult);
   }
 
-  /** Adding and removing regexps. */
+  /** Adding regexps. */
   @Test
-  public void testAddRemoveRegexp() throws RegexpParserException {
+  public void testAddRegexp() throws RegexpParserException {
     assertFalse(rs.hasRegexp(reString));
     rs.add(reString, a);
     assertTrue(rs.hasRegexp(reString));
-    rs.remove(reString, a);
-    assertFalse(rs.hasRegexp(reString));
   }
 
   /** Retrieving stuff that is stored. */

--- a/rmatch/src/test/java/no/rmz/rmatch/integrationtests/APlusTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/integrationtests/APlusTest.java
@@ -13,8 +13,6 @@
  */
 package no.rmz.rmatch.integrationtests;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -82,16 +80,6 @@ public final class APlusTest {
         };
 
     m = TestMatchers.newSingleMatcher(compiler, regexpFactory);
-  }
-
-  /**
-   * This is kind of a tripwire test. It was written since no actions were run i testMockedMatch.
-   */
-  @Test
-  public void testActionTransferToRegexpThroughRegexpStorage() throws RegexpParserException {
-    assertFalse(regexp.hasActions(), "the regexp should not initially have actions");
-    m.add(aplusString, action);
-    assertTrue(regexp.hasActions(), "the regexp should have actions");
   }
 
   /** Check that the string "ab" matches. */

--- a/rmatch/src/test/java/no/rmz/rmatch/integrationtests/ATest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/integrationtests/ATest.java
@@ -13,8 +13,6 @@
  */
 package no.rmz.rmatch.compiler;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -75,16 +73,6 @@ public final class ATest {
         };
 
     m = TestMatchers.newSingleMatcher(compiler, regexpFactory);
-  }
-
-  /**
-   * This is kind of a tripwire test. It was written since no actions were run i testMockedMatch.
-   */
-  @Test
-  public void testActionTransferToRegexpThroughRegexpStorage() throws RegexpParserException {
-    assertFalse(regexp.hasActions(), "the regexp should not initially have actions");
-    m.add(aString, action);
-    assertTrue(regexp.hasActions(), "the regexp should have actions");
   }
 
   /** Look for a match terminated by the character "b". */

--- a/rmatch/src/test/java/no/rmz/rmatch/integrationtests/AorBTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/integrationtests/AorBTest.java
@@ -13,8 +13,6 @@
  */
 package no.rmz.rmatch.compiler;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -77,16 +75,6 @@ public final class AorBTest {
         };
 
     m = TestMatchers.newSingleMatcher(compiler, regexpFactory);
-  }
-
-  /**
-   * This is kind of a tripwire test. It was written since no actions were run i testMockedMatch.
-   */
-  @Test
-  public void testActionTransferToRegexpThroughRegexpStorage() throws RegexpParserException {
-    assertFalse(regexp.hasActions(), "the regexp should not initially have actions");
-    m.add(aOrBString, action);
-    assertTrue(regexp.hasActions(), "the regexp should have actions");
   }
 
   /** Look for match in first alternative. */

--- a/rmatch/src/test/java/no/rmz/rmatch/integrationtests/SequenceNodeTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/integrationtests/SequenceNodeTest.java
@@ -13,8 +13,6 @@
  */
 package no.rmz.rmatch.compiler;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import no.rmz.rmatch.Action;
@@ -109,14 +107,6 @@ public class SequenceNodeTest {
         };
 
     m = TestMatchers.newSingleMatcher(compiler, regexpFactory);
-  }
-
-  /** Test adding an action to the regexp. */
-  @Test
-  public final void testActionTransferToRegexpThroughRegexpStorage() throws RegexpParserException {
-    assertFalse(abRegexp.hasActions(), "the regexp should not initially have actions");
-    m.add(AB_STRING, action);
-    assertTrue(abRegexp.hasActions(), "the regexp should have actions");
   }
 
   /** Test performing a match on "ab". */

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/MatcherContractTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/MatcherContractTest.java
@@ -40,7 +40,6 @@ public class MatcherContractTest {
 
     assertThrows(IllegalStateException.class, () -> m.match(RMatch.stringBuffer("a")));
     assertThrows(IllegalStateException.class, () -> m.add("b", (b, start, end) -> {}));
-    assertThrows(IllegalStateException.class, () -> m.remove("a", (b, start, end) -> {}));
   }
 
   @Test
@@ -51,7 +50,6 @@ public class MatcherContractTest {
 
     assertThrows(IllegalStateException.class, () -> m.match(RMatch.stringBuffer("a")));
     assertThrows(IllegalStateException.class, () -> m.add("b", (b, start, end) -> {}));
-    assertThrows(IllegalStateException.class, () -> m.remove("a", (b, start, end) -> {}));
   }
 
   @Test

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/PatternFlagUsageTest.java
@@ -73,21 +73,6 @@ public class PatternFlagUsageTest {
   }
 
   @Test
-  public void removeWithSameFlagsRemovesTheRegistration() throws Exception {
-    try (Matcher m = RMatch.newSingleMatcher()) {
-      final Set<String> found = new TreeSet<>();
-      final no.rmz.rmatch.Action action = (b, start, end) -> found.add(b.getString(start, end));
-
-      m.add("warn", Set.of(PatternFlag.CASE_INSENSITIVE), action);
-      m.remove("warn", Set.of(PatternFlag.CASE_INSENSITIVE), action);
-
-      m.match(RMatch.stringBuffer("warn WARN"));
-
-      assertEquals(Set.of(), found, "removed registration must not fire");
-    }
-  }
-
-  @Test
   public void flaggedAddWorksOnPartitionedMatcher() throws Exception {
     try (Matcher m = RMatch.newMatcher()) {
       final Set<String> found = new ConcurrentSkipListSet<>();

--- a/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/RegistrationContractTest.java
+++ b/rmatch/src/test/java/no/rmz/rmatch/ordinaryuse/RegistrationContractTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2026. Bjørn Remseth (rmz@rmz.no).
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.rmz.rmatch.ordinaryuse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+import no.rmz.rmatch.Action;
+import no.rmz.rmatch.Buffer;
+import no.rmz.rmatch.Matcher;
+import no.rmz.rmatch.RMatch;
+import org.junit.jupiter.api.Test;
+
+/** Contract tests for the register-then-match lifecycle and callback identity. */
+public class RegistrationContractTest {
+
+  @Test
+  void firstMatchFreezesSingleMatcherRegistrations() throws Exception {
+    assertRegistrationFreezes(RMatch::newSingleMatcher);
+  }
+
+  @Test
+  void firstMatchFreezesPartitionedMatcherRegistrations() throws Exception {
+    assertRegistrationFreezes(() -> RMatch.newMatcher(4));
+  }
+
+  @Test
+  void emptyFirstScanStillFreezesRegistration() throws Exception {
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      matcher.match(RMatch.stringBuffer(""));
+
+      assertThrows(
+          IllegalStateException.class, () -> matcher.add("abc", (buffer, start, end) -> {}));
+    }
+  }
+
+  @Test
+  void failedFirstScanStillFreezesRegistration() throws Exception {
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      matcher.add(
+          "boom",
+          (buffer, start, end) -> {
+            throw new IllegalStateException("deliberate failure");
+          });
+
+      assertThrows(IllegalStateException.class, () -> matcher.match(RMatch.stringBuffer("boom")));
+      assertThrows(
+          IllegalStateException.class, () -> matcher.add("abc", (buffer, start, end) -> {}));
+    }
+  }
+
+  @Test
+  void registeringTheSameActionInstanceTwiceIsIdempotent() throws Exception {
+    final LongAdder calls = new LongAdder();
+    final Action action = (buffer, start, end) -> calls.increment();
+
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      matcher.add("abc", action);
+      matcher.add("abc", action);
+      matcher.match(RMatch.stringBuffer("abc"));
+    }
+
+    assertEquals(1L, calls.sum());
+  }
+
+  @Test
+  void distinctActionInstancesRemainDistinctEvenWhenTheyCompareEqual() throws Exception {
+    final LongAdder calls = new LongAdder();
+
+    try (Matcher matcher = RMatch.newSingleMatcher()) {
+      matcher.add("abc", new EqualAction(calls));
+      matcher.add("abc", new EqualAction(calls));
+      matcher.match(RMatch.stringBuffer("abc"));
+    }
+
+    assertEquals(2L, calls.sum());
+  }
+
+  @Test
+  void publicMatcherSurfaceDoesNotOfferExperimentalRemoval() {
+    assertFalse(
+        Arrays.stream(Matcher.class.getMethods())
+            .anyMatch(method -> method.getName().equals("remove")));
+  }
+
+  private static void assertRegistrationFreezes(final Supplier<Matcher> factory) throws Exception {
+    try (Matcher matcher = factory.get()) {
+      matcher.add("abc", (buffer, start, end) -> {});
+      matcher.match(RMatch.stringBuffer("abc"));
+
+      assertThrows(
+          IllegalStateException.class, () -> matcher.add("xyz", (buffer, start, end) -> {}));
+    }
+  }
+
+  private static final class EqualAction implements Action {
+    private final LongAdder calls;
+
+    private EqualAction(final LongAdder calls) {
+      this.calls = calls;
+    }
+
+    @Override
+    public void performMatch(final Buffer buffer, final long start, final long end) {
+      calls.increment();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      return other instanceof EqualAction;
+    }
+
+    @Override
+    public int hashCode() {
+      return EqualAction.class.hashCode();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- adopt a build-then-use lifecycle: the first `match()` permanently freezes registration and later `add()` calls fail explicitly
- remove the experimental `Matcher.remove(...)` surface and its stale internal graph-removal plumbing
- define duplicate registration by action object identity: the same instance is idempotent, distinct equal instances both remain registered
- state that callback ordering is unspecified for both single and partitioned matchers
- remove the now-dead internal `Regexp.hasActions()` query and update README, changelog, Javadocs, and the 2.0 checklist

This replaces runtime mutation that was not safe enough to freeze for 2.0. Removal could leave compiled graph state behind, re-adding a fully removed pattern could silently stop callbacks, and adding patterns after scanning could reuse stale transition caches. Applications that need a changed rule set now construct a replacement matcher.

## Test-first evidence

The new contract suite was added first and initially reported four expected failures: both matcher implementations accepted late registration, equal-but-distinct actions collapsed, and `remove` remained public. It now covers successful, empty, and callback-failing first scans; single and partitioned freezing; identity semantics; idempotent duplicate registration; and the absence of `remove` from the facade.

## Verification

- full `./mvnw -q -B spotless:apply verify` reactor: pass
- strict Javadoc generation: pass
- external Maven, Gradle, plain-classpath, and named-JPMS consumers: pass
- packaged public API inspected with `javap`; `Matcher` contains only `add`, `match`, and `close`
- Agogo Java 26 Docker B/C/C/B gate, 10,000 patterns, 1 MB and 10 MB corpora: pass with identical input hashes and match counts
  - 1 MB balanced median candidate/baseline: `0.931`
  - 10 MB balanced median candidate/baseline: `0.980`
  - one candidate 1 MB observation was a `9.752 s` outlier; the other candidate observations were `2.370 s`, `2.442 s`, and `2.446 s`, so the balanced median remained below baseline

Agogo receipts remain at `/home/rmz/git/rmatch-agogo-registration-gate-20260710_1415`.