### PR TITLE
Refresh front-page benchmark evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,29 @@ The public comparison model is:
   RE2J regex over the corpus.
 - rmatch: register the same pattern set in one matcher and scan the corpus once.
 
-Current release gates use byte-identical inputs and require match counts to
-agree before timing numbers are treated as public evidence. A fresh Docker run
-on a 32-logical-CPU AMD Ryzen 9 9950X3D machine on 2026-07-07 used deterministic
-literal-token patterns over an 8 MiB corpus. The 1k-pattern case still favors
-RE2J, which is expected for smaller literal workloads. At 5k and 10k patterns,
-the one-pass rmatch scan pulls ahead while the per-pattern loops continue to
-scale with the number of patterns.
+Current measurements use byte-identical inputs and require match counts to
+agree before a timing is retained. The charts below come from Docker runs on a
+16-core / 32-thread AMD Ryzen 9 9950X3D using deterministic 8 MiB fixtures with
+1,000 and 10,000 patterns. The logarithmic view keeps Hyperscan, rmatch, RE2/J,
+and Java regex legible on one scale.
 
-![rmatch README efficiency comparison](docs/benchmark-receipts/agogo-2026-07-07/readme-efficiency-large/readme-efficiency-scanning.svg)
+![Logarithmic comparison of Hyperscan, rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg)
 
-| Patterns | Match count | rmatch (s) | RE2J (s) | Java regex loop (s) |
-|---:|---:|---:|---:|---:|
-| 1,000 | 11,000 | 1.885 | 1.143 | 3.091 |
-| 5,000 | 52,721 | 2.075 | 4.073 | 15.314 |
-| 10,000 | 102,721 | 2.316 | 7.914 | 30.740 |
+The linear view makes the JVM comparison easier to read. `1T` means one
+worker. The parallel RE2/J and Java lanes partition independent, precompiled
+patterns across workers; rmatch is represented by its public single-engine
+factory. Those are deliberately labeled as different execution models rather
+than collapsed into one supposedly universal ranking.
 
-The raw receipts, chart inputs, and earlier diagnostic runs are checked in
-under
-[docs/benchmark-receipts/agogo-2026-07-07](docs/benchmark-receipts/agogo-2026-07-07).
+![Linear comparison of rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/jvm-engine-comparison-linear.svg)
+
+These are exploratory measurements from a benchmark project that is only just
+getting started, not a systematic testing campaign or a final verdict. The
+workloads are generated, the scenario set is still small, and wider syntax,
+corpora, machines, match densities, and resource controls remain to be tested.
+The harness, methodology, and auditable receipts live in the
+[rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements).
+Watch this space.
 
 Use rmatch when the workload looks like this:
 

--- a/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+<title id="title">Four engines, one task, very different scales</title>
+<desc id="desc">Exploratory 8 MiB generated fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; logarithmic task throughput</desc>
+<rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
+<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Four engines, one task, very different scales</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB generated fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; logarithmic task throughput</text>
+<rect x="72" y="130" width="17" height="17" rx="3" fill="#087e8b"/>
+<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T</text>
+<rect x="199" y="130" width="17" height="17" rx="3" fill="#e4572e"/>
+<text x="224" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch 1T</text>
+<rect x="302" y="130" width="17" height="17" rx="3" fill="#6f95ca"/>
+<text x="327" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
+<rect x="421" y="130" width="17" height="17" rx="3" fill="#9a9fa6"/>
+<text x="446" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex 128T</text>
+<line x1="110" y1="620.0" x2="1140" y2="620.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="625.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Mbit/s</text>
+<line x1="110" y1="547.5" x2="1140" y2="547.5" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="552.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Mbit/s</text>
+<line x1="110" y1="475.0" x2="1140" y2="475.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="480.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Mbit/s</text>
+<line x1="110" y1="402.5" x2="1140" y2="402.5" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="407.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Gbit/s</text>
+<line x1="110" y1="330.0" x2="1140" y2="330.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="335.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Gbit/s</text>
+<line x1="110" y1="257.5" x2="1140" y2="257.5" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="262.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Gbit/s</text>
+<line x1="110" y1="185.0" x2="1140" y2="185.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="190.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1000 Gbit/s</text>
+<rect x="150.5" y="227.5" width="31" height="392.5" rx="4" fill="#087e8b"/>
+<text transform="translate(166.0,220.5) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">259,421</text>
+<rect x="410.5" y="268.9" width="31" height="351.1" rx="4" fill="#087e8b"/>
+<text transform="translate(426.0,261.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">69,634</text>
+<rect x="680.5" y="260.0" width="31" height="360.0" rx="4" fill="#087e8b"/>
+<text transform="translate(696.0,253.0) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">92,393</text>
+<rect x="940.5" y="342.9" width="31" height="277.1" rx="4" fill="#087e8b"/>
+<text transform="translate(956.0,335.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">6,647</text>
+<rect x="186.5" y="419.0" width="31" height="201.0" rx="4" fill="#e4572e"/>
+<text transform="translate(202.0,412.0) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">591</text>
+<rect x="446.5" y="441.7" width="31" height="178.3" rx="4" fill="#e4572e"/>
+<text transform="translate(462.0,434.7) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">288</text>
+<rect x="716.5" y="407.8" width="31" height="212.2" rx="4" fill="#e4572e"/>
+<text transform="translate(732.0,400.8) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">846</text>
+<rect x="976.5" y="438.6" width="31" height="181.4" rx="4" fill="#e4572e"/>
+<text transform="translate(992.0,431.6) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">317</text>
+<rect x="222.5" y="376.6" width="31" height="243.4" rx="4" fill="#6f95ca"/>
+<text transform="translate(238.0,369.6) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">2,277</text>
+<rect x="482.5" y="448.8" width="31" height="171.2" rx="4" fill="#6f95ca"/>
+<text transform="translate(498.0,441.8) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">229</text>
+<rect x="752.5" y="377.1" width="31" height="242.9" rx="4" fill="#6f95ca"/>
+<text transform="translate(768.0,370.1) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">2,237</text>
+<rect x="1012.5" y="448.5" width="31" height="171.5" rx="4" fill="#6f95ca"/>
+<text transform="translate(1028.0,441.5) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">232</text>
+<rect x="258.5" y="396.7" width="31" height="223.3" rx="4" fill="#9a9fa6"/>
+<text transform="translate(274.0,389.7) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">1,201</text>
+<rect x="518.5" y="470.2" width="31" height="149.8" rx="4" fill="#9a9fa6"/>
+<text transform="translate(534.0,463.2) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">116</text>
+<rect x="788.5" y="411.9" width="31" height="208.1" rx="4" fill="#9a9fa6"/>
+<text transform="translate(804.0,404.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">741</text>
+<rect x="1048.5" y="482.4" width="31" height="137.6" rx="4" fill="#9a9fa6"/>
+<text transform="translate(1064.0,475.4) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="11" fill="#27333d">79</text>
+<text x="220.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Diverse literals</text>
+<text x="220.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">1,000 patterns</text>
+<text x="480.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Diverse literals</text>
+<text x="480.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">10,000 patterns</text>
+<text x="750.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Mixed regex</text>
+<text x="750.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">1,000 patterns</text>
+<text x="1010.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Mixed regex</text>
+<text x="1010.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">10,000 patterns</text>
+<text x="25" y="410" transform="rotate(-90 25 410)" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">Whole-task throughput (log scale)</text>
+</svg>

--- a/docs/benchmark-plots/exploratory-2026-07-10/jvm-engine-comparison-linear.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-10/jvm-engine-comparison-linear.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+<title id="title">JVM engines: single-thread and parallel task throughput</title>
+<desc id="desc">Same 8 MiB fixtures; rmatch uses its public single-engine factory, while RE2/J and Java regex also show tuned parallel task lanes</desc>
+<rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
+<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">JVM engines: single-thread and parallel task throughput</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Same 8 MiB fixtures; rmatch uses its public single-engine factory, while RE2/J and Java regex also show tuned parallel task lanes</text>
+<rect x="72" y="130" width="17" height="17" rx="3" fill="#e4572e"/>
+<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch 1T</text>
+<rect x="175" y="130" width="17" height="17" rx="3" fill="#315c9b"/>
+<text x="200" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J 1T</text>
+<rect x="270" y="130" width="17" height="17" rx="3" fill="#4d5259"/>
+<text x="295" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex 1T</text>
+<rect x="405" y="130" width="17" height="17" rx="3" fill="#6f95ca"/>
+<text x="430" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
+<rect x="524" y="130" width="17" height="17" rx="3" fill="#9a9fa6"/>
+<text x="549" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex 128T</text>
+<line x1="96" y1="620.0" x2="1140" y2="620.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="625.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">0</text>
+<line x1="96" y1="533.0" x2="1140" y2="533.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="538.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">500</text>
+<line x1="96" y1="446.0" x2="1140" y2="446.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="451.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1,000</text>
+<line x1="96" y1="359.0" x2="1140" y2="359.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="364.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1,500</text>
+<line x1="96" y1="272.0" x2="1140" y2="272.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="277.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">2,000</text>
+<line x1="96" y1="185.0" x2="1140" y2="185.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="84" y="190.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">2,500</text>
+<rect x="130.5" y="517.1" width="27" height="102.9" rx="4" fill="#e4572e"/>
+<text transform="translate(144.0,510.1) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">591</text>
+<rect x="395.5" y="569.9" width="27" height="50.1" rx="4" fill="#e4572e"/>
+<text transform="translate(409.0,562.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">288</text>
+<rect x="665.5" y="472.9" width="27" height="147.1" rx="4" fill="#e4572e"/>
+<text transform="translate(679.0,465.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">846</text>
+<rect x="930.5" y="564.8" width="27" height="55.2" rx="4" fill="#e4572e"/>
+<text transform="translate(944.0,557.8) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">317</text>
+<rect x="163.5" y="590.0" width="27" height="30.0" rx="4" fill="#315c9b"/>
+<rect x="428.5" y="617.1" width="27" height="2.9" rx="4" fill="#315c9b"/>
+<rect x="698.5" y="589.4" width="27" height="30.6" rx="4" fill="#315c9b"/>
+<rect x="963.5" y="617.0" width="27" height="3.0" rx="4" fill="#315c9b"/>
+<rect x="196.5" y="610.8" width="27" height="9.2" rx="4" fill="#4d5259"/>
+<rect x="461.5" y="619.1" width="27" height="0.9" rx="4" fill="#4d5259"/>
+<rect x="731.5" y="614.3" width="27" height="5.7" rx="4" fill="#4d5259"/>
+<rect x="996.5" y="619.4" width="27" height="0.6" rx="4" fill="#4d5259"/>
+<rect x="229.5" y="223.9" width="27" height="396.1" rx="4" fill="#6f95ca"/>
+<text transform="translate(243.0,216.9) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">2,277</text>
+<rect x="494.5" y="580.1" width="27" height="39.9" rx="4" fill="#6f95ca"/>
+<text transform="translate(508.0,573.1) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">229</text>
+<rect x="764.5" y="230.7" width="27" height="389.3" rx="4" fill="#6f95ca"/>
+<text transform="translate(778.0,223.7) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">2,237</text>
+<rect x="1029.5" y="579.6" width="27" height="40.4" rx="4" fill="#6f95ca"/>
+<text transform="translate(1043.0,572.6) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">232</text>
+<rect x="262.5" y="411.0" width="27" height="209.0" rx="4" fill="#9a9fa6"/>
+<text transform="translate(276.0,404.0) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">1,201</text>
+<rect x="527.5" y="599.8" width="27" height="20.2" rx="4" fill="#9a9fa6"/>
+<rect x="797.5" y="491.0" width="27" height="129.0" rx="4" fill="#9a9fa6"/>
+<text transform="translate(811.0,484.0) rotate(-55)" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#27333d">741</text>
+<rect x="1062.5" y="606.2" width="27" height="13.8" rx="4" fill="#9a9fa6"/>
+<text x="210.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Diverse literals</text>
+<text x="210.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">1,000 patterns</text>
+<text x="475.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Diverse literals</text>
+<text x="475.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">10,000 patterns</text>
+<text x="745.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Mixed regex</text>
+<text x="745.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">1,000 patterns</text>
+<text x="1010.0" y="650" text-anchor="middle" font-family="Verdana, sans-serif" font-size="14" font-weight="700" fill="#27333d">Mixed regex</text>
+<text x="1010.0" y="671" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#687580">10,000 patterns</text>
+<text x="23" y="410" transform="rotate(-90 23 410)" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">Whole-task throughput (Mbit/s)</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the older favorable front-page chart with exploratory four-engine measurements
- add logarithmic and linear JVM views generated from archived, match-validated receipts
- link the dedicated benchmark project and state the present limitations plainly

## Verification
- SVGs validated with xmllint
- charts visually inspected after raster rendering
- documentation-only change; no runtime code changed