### PR TITLE
Release rmatch 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.9.6-SNAPSHOT - in development
+## 1.9.6 - pre-2.0 Maven Central release candidate
 
 - Continue pre-2.0 cleanup after publishing `1.9.5`.
 - Added `RMatch.newMatcher(int parallelism)` so applications can choose the

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The branch-vs-`main` protocol lives in
 
 ## Use from Maven Central
 
-The examples below use the public API published with `1.9.5`.
+The examples below use the public API published with `1.9.6`.
 
 Add rmatch to an existing Maven project:
 
@@ -81,7 +81,7 @@ Add rmatch to an existing Maven project:
 <dependency>
   <groupId>no.rmz</groupId>
   <artifactId>rmatch</artifactId>
-  <version>1.9.5</version>
+  <version>1.9.6</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ For Gradle:
 
 ```kotlin
 dependencies {
-    implementation("no.rmz:rmatch:1.9.5")
+    implementation("no.rmz:rmatch:1.9.6")
 }
 ```
 
@@ -127,7 +127,7 @@ For a complete scratch project, use this full `pom.xml`:
     <dependency>
       <groupId>no.rmz</groupId>
       <artifactId>rmatch</artifactId>
-      <version>1.9.5</version>
+      <version>1.9.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -232,6 +232,23 @@ the rest of the release work here as it becomes explicit.
   `./mvnw -q -B -pl rmatch -am -DskipTests -Dspotbugs.skip=true verify`
   succeeded.
 
+## 1.9.6 Release Run
+
+- [x] Sync a clean release worktree from current `origin/main` at
+  `43aaae52382efdb774435f1dba39c442779aaa4f`.
+- [x] Set release POM versions, changelog heading, and README examples to
+  `1.9.6`.
+- [x] Run full release preflight and Central profile checks. Both succeeded on
+  2026-07-12.
+- [ ] Build and verify signed release artifacts, module metadata, Java baseline,
+  compile dependency tree, and public Javadocs.
+- [ ] Publish `1.9.6` through Central and confirm repository availability.
+- [ ] Run clean-repository Maven consumer smoke tests against Central.
+- [ ] Create and push the annotated `rmatch-1.9.6` tag.
+- [ ] Move `main` to `1.9.7-SNAPSHOT` after the release merge.
+- [ ] Rerun the throughput-winning parallelism lanes from the published
+  `no.rmz:rmatch:1.9.6` artifact before updating public benchmark charts.
+
 ## Identity and Access
 
 - [x] Create a current GPG release-signing key.

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -240,14 +240,21 @@ the rest of the release work here as it becomes explicit.
   `1.9.6`.
 - [x] Run full release preflight and Central profile checks. Both succeeded on
   2026-07-12.
-- [ ] Build and verify signed release artifacts, module metadata, Java baseline,
+- [x] Build and verify signed release artifacts, module metadata, Java baseline,
   compile dependency tree, and public Javadocs.
-- [ ] Publish `1.9.6` through Central and confirm repository availability.
-- [ ] Run clean-repository Maven consumer smoke tests against Central.
-- [ ] Create and push the annotated `rmatch-1.9.6` tag.
+- [x] Publish `1.9.6` through Central deployment
+  `0156bf75-b742-4220-a846-2720281ceee0` and confirm the POM, main JAR,
+  Javadoc JAR, and parent POM return HTTP 200 from Maven Central.
+- [x] Run a clean-repository Maven consumer smoke test against Central,
+  including `RMatch.newMatcher(2)` and exact match-count validation.
+- [x] Create and push the annotated `rmatch-1.9.6` tag at release commit
+  `caf33fb9`.
 - [ ] Move `main` to `1.9.7-SNAPSHOT` after the release merge.
-- [ ] Rerun the throughput-winning parallelism lanes from the published
+- [x] Rerun the throughput-winning parallelism lanes from the published
   `no.rmz:rmatch:1.9.6` artifact before updating public benchmark charts.
+  Nine measured scans after three warm-ups passed exact validation for all four
+  scenarios; the retained winners use two workers at 1K patterns and four at
+  10K patterns.
 
 ## Identity and Access
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-parent</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.9.6</version>
 
     <packaging>pom</packaging>
 

--- a/rmatch-tester/pom.xml
+++ b/rmatch-tester/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.9.6</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-tester</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.9.6</version>
     <packaging>jar</packaging>
 
     <name>rmatch-tester</name>

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.9.6</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.9.6</version>
     <packaging>jar</packaging>
 
     <name>rmatch</name>


### PR DESCRIPTION
## Summary
- publish the explicit matcher-parallelism API and stabilized matcher lifecycle as 1.9.6
- update Maven/Gradle examples and changelog
- record signed artifact, Central, consumer, tag, and benchmark verification

## Release evidence
- Central deployment: 0156bf75-b742-4220-a846-2720281ceee0 (PUBLISHED)
- tag: rmatch-1.9.6 at caf33fb9
- clean Maven repository smoke exercised RMatch.newMatcher(2)
- published-artifact benchmark winners passed exact match validation