### PR TITLE
Start 1.9.7 snapshot with calibrated benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.7-SNAPSHOT - in development
+
+- Continue pre-2.0 stabilization after publishing `1.9.6`.
+
 ## 1.9.6 - pre-2.0 Maven Central release candidate
 
 - Continue pre-2.0 cleanup after publishing `1.9.5`.

--- a/README.md
+++ b/README.md
@@ -32,24 +32,25 @@ The public comparison model is:
 Current measurements use byte-identical inputs and require match counts to
 agree before a timing is retained. The chart below comes from Docker runs on a
 16-core / 32-thread AMD Ryzen 9 9950X3D using deterministic 8 MiB fixtures with
-1,000 and 10,000 patterns. The logarithmic view keeps Hyperscan, rmatch, RE2/J,
-and Java regex legible on one scale. Each line runs from 1,000 to 10,000
-patterns, making the engines' different scaling profiles visible.
+1,000 and 10,000 patterns. Each JVM engine uses the highest-throughput worker
+count found in its calibration sweep: rmatch 1.9.6 uses two workers at 1K and
+four at 10K, RE2/J uses 128 and 256, and Java regex uses 128. Hyperscan is the
+explicitly labeled one-thread native reference, included to show the much
+higher native-performance ceiling rather than as an execution-model peer.
 
-![Logarithmic comparison of Hyperscan, rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg)
+![Maximum retained throughput of Hyperscan, rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg)
 
-`1T` means one worker. The parallel RE2/J and Java lanes partition independent,
-precompiled patterns across workers; rmatch is represented by its public
-single-engine factory. Those are deliberately labeled as different execution
-models rather than collapsed into one supposedly universal ranking. The
-benchmark project contains the more detailed linear JVM view.
+This is deliberately a “push each engine” comparison, not an equal-CPU-budget
+comparison. At 1K patterns tuned RE2/J leads the JVM lanes. At 10K patterns
+rmatch leads both retained RE2/J and Java lanes. The logarithmic scale keeps
+Hyperscan and the JVM results legible in one chart.
 
 These are exploratory measurements from a benchmark project that is only just
 getting started, not a systematic testing campaign or a final verdict. The
 workloads are generated, the scenario set is still small, and wider syntax,
 corpora, machines, match densities, and resource controls remain to be tested.
-The harness, methodology, and auditable receipts live in the
-[rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements).
+The harness, calibration sweeps, methodology, and all 16 winner receipts live
+in the [rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements/tree/main/receipts/agogo-2026-07-12-max-throughput).
 Watch this space.
 
 Use rmatch when the workload looks like this:

--- a/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
@@ -1,21 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
-<title id="title">Four engines, one task, very different scales</title>
-<desc id="desc">Exploratory 8 MiB generated fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; logarithmic task throughput</desc>
+<title id="title">Maximum retained throughput by engine</title>
+<desc id="desc">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated winner</desc>
 <rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
-<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Four engines, one task, very different scales</text>
-<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB generated fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; logarithmic task throughput</text>
+<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Maximum retained throughput by engine</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated winner</text>
 <line x1="72" y1="138" x2="90" y2="138" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
 <circle cx="81" cy="138" r="4" fill="#f7f4ed" stroke="#087e8b" stroke-width="3"/>
-<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T</text>
-<line x1="199" y1="138" x2="217" y2="138" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
-<circle cx="208" cy="138" r="4" fill="#f7f4ed" stroke="#e4572e" stroke-width="3"/>
-<text x="224" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch 1T</text>
-<line x1="302" y1="138" x2="320" y2="138" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
-<circle cx="311" cy="138" r="4" fill="#f7f4ed" stroke="#6f95ca" stroke-width="3"/>
-<text x="327" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
-<line x1="421" y1="138" x2="439" y2="138" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
-<circle cx="430" cy="138" r="4" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="3"/>
-<text x="446" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex 128T</text>
+<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T (native reference)</text>
+<line x1="351" y1="138" x2="369" y2="138" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
+<circle cx="360" cy="138" r="4" fill="#f7f4ed" stroke="#e4572e" stroke-width="3"/>
+<text x="376" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch tuned</text>
+<line x1="478" y1="138" x2="496" y2="138" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
+<circle cx="487" cy="138" r="4" fill="#f7f4ed" stroke="#6f95ca" stroke-width="3"/>
+<text x="503" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
+<line x1="597" y1="138" x2="615" y2="138" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
+<circle cx="606" cy="138" r="4" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="3"/>
+<text x="622" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex tuned</text>
 <line x1="110" y1="625.0" x2="1130" y2="625.0" stroke="#d9d5ca" stroke-width="1"/>
 <text x="96" y="630.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Mbit/s</text>
 <line x1="110" y1="555.0" x2="1130" y2="555.0" stroke="#d9d5ca" stroke-width="1"/>
@@ -41,11 +41,11 @@
 <text x="172" y="237.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">259,421</text>
 <circle cx="513" cy="286.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
 <text x="523" y="277.0" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">69,634</text>
-<path d="M 182 431.0 L 513 452.9" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
-<circle cx="182" cy="431.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="172" y="422.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">591</text>
-<circle cx="513" cy="452.9" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="523" y="443.9" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">288</text>
+<path d="M 182 426.0 L 513 454.7" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
+<circle cx="182" cy="426.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="172" y="417.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">696</text>
+<circle cx="513" cy="454.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="523" y="445.7" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">271</text>
 <path d="M 182 390.0 L 513 459.8" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
 <circle cx="182" cy="390.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
 <text x="172" y="381.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,277</text>
@@ -67,11 +67,11 @@
 <text x="717" y="268.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">92,393</text>
 <circle cx="1058" cy="357.4" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
 <text x="1068" y="348.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">6,647</text>
-<path d="M 727 420.1 L 1058 449.9" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
-<circle cx="727" cy="420.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="717" y="411.1" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">846</text>
-<circle cx="1058" cy="449.9" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="1068" y="440.9" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">317</text>
+<path d="M 727 421.4 L 1058 441.1" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
+<circle cx="727" cy="421.4" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="717" y="412.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">811</text>
+<circle cx="1058" cy="441.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="1068" y="432.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">423</text>
 <path d="M 727 390.5 L 1058 459.4" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
 <circle cx="727" cy="390.5" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
 <text x="717" y="381.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,237</text>

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -249,7 +249,7 @@ the rest of the release work here as it becomes explicit.
   including `RMatch.newMatcher(2)` and exact match-count validation.
 - [x] Create and push the annotated `rmatch-1.9.6` tag at release commit
   `caf33fb9`.
-- [ ] Move `main` to `1.9.7-SNAPSHOT` after the release merge.
+- [x] Move `main` to `1.9.7-SNAPSHOT` after the release merge.
 - [x] Rerun the throughput-winning parallelism lanes from the published
   `no.rmz:rmatch:1.9.6` artifact before updating public benchmark charts.
   Nine measured scans after three warm-ups passed exact validation for all four

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-parent</artifactId>
-    <version>1.9.6</version>
+    <version>1.9.7-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/rmatch-tester/pom.xml
+++ b/rmatch-tester/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.6</version>
+        <version>1.9.7-SNAPSHOT</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-tester</artifactId>
-    <version>1.9.6</version>
+    <version>1.9.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>rmatch-tester</name>

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.6</version>
+        <version>1.9.7-SNAPSHOT</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch</artifactId>
-    <version>1.9.6</version>
+    <version>1.9.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>rmatch</name>


### PR DESCRIPTION
## Summary
- move development versions to 1.9.7-SNAPSHOT after the published 1.9.6 release
- replace the front-page single-engine comparison with one calibrated maximum-throughput chart
- state exact worker counts and distinguish the Hyperscan native reference
- link the 16 validated winner receipts and full calibration sweeps

## Verification
- published-artifact rmatch lanes ran 9 measured scans after 3 warm-ups with exact match counts
- SVG validated with xmllint and rendered for inspection
- Maven verify passed for parent and rmatch at 1.9.7-SNAPSHOT