### PR TITLE
Add calibrated 5K benchmark midpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,27 @@ The public comparison model is:
 Current measurements use byte-identical inputs and require match counts to
 agree before a timing is retained. The chart below comes from Docker runs on a
 16-core / 32-thread AMD Ryzen 9 9950X3D using deterministic 8 MiB fixtures with
-1,000 and 10,000 patterns. Each JVM engine uses the highest-throughput worker
-count found in its calibration sweep: rmatch 1.9.6 uses two workers at 1K and
-four at 10K, RE2/J uses 128 and 256, and Java regex uses 128. Hyperscan is the
-explicitly labeled one-thread native reference, included to show the much
-higher native-performance ceiling rather than as an execution-model peer.
+1,000, 5,000, and 10,000 patterns. Each JVM engine uses the highest-throughput
+worker count found in its calibration sweep. rmatch 1.9.6 uses two workers at
+1K and four at 5K and 10K. The per-pattern engines use heavier task
+oversubscription: their exact retained settings are recorded with the receipts.
+Hyperscan is the explicitly labeled one-thread native reference, included to
+show the much higher native-performance ceiling rather than as an
+execution-model peer.
 
 ![Maximum retained throughput of Hyperscan, rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg)
 
 This is deliberately a “push each engine” comparison, not an equal-CPU-budget
-comparison. At 1K patterns tuned RE2/J leads the JVM lanes. At 10K patterns
-rmatch leads both retained RE2/J and Java lanes. The logarithmic scale keeps
-Hyperscan and the JVM results legible in one chart.
+comparison. At 1K patterns tuned RE2/J leads the JVM lanes. At 5K the result is
+workload-dependent: RE2/J leads on diverse literals, while rmatch leads on the
+mixed-regex family. At 10K rmatch leads both retained RE2/J and Java lanes. The
+logarithmic scale keeps Hyperscan and the JVM results legible in one chart.
 
 These are exploratory measurements from a benchmark project that is only just
 getting started, not a systematic testing campaign or a final verdict. The
 workloads are generated, the scenario set is still small, and wider syntax,
 corpora, machines, match densities, and resource controls remain to be tested.
-The harness, calibration sweeps, methodology, and all 16 winner receipts live
+The harness, calibration sweeps, methodology, and all 24 winner receipts live
 in the [rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements/tree/main/receipts/agogo-2026-07-12-max-throughput).
 Watch this space.
 

--- a/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
@@ -32,55 +32,75 @@
 <text x="96" y="210.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1000 Gbit/s</text>
 <rect x="110" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
 <text x="347.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Diverse literals</text>
-<line x1="182" y1="205" x2="182" y2="625" stroke="#e8e4da" stroke-width="1"/>
-<text x="182" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000 patterns</text>
-<line x1="513" y1="205" x2="513" y2="625" stroke="#e8e4da" stroke-width="1"/>
-<text x="513" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000 patterns</text>
-<path d="M 182 246.0 L 513 286.0" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
-<circle cx="182" cy="246.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
-<text x="172" y="237.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">259,421</text>
-<circle cx="513" cy="286.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
-<text x="523" y="277.0" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">69,634</text>
-<path d="M 182 426.0 L 513 454.7" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
-<circle cx="182" cy="426.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="172" y="417.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">696</text>
-<circle cx="513" cy="454.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="523" y="445.7" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">271</text>
-<path d="M 182 390.0 L 513 459.8" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
-<circle cx="182" cy="390.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
-<text x="172" y="381.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,277</text>
-<circle cx="513" cy="459.8" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
-<text x="523" y="450.8" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">229</text>
-<path d="M 182 409.4 L 513 480.4" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
-<circle cx="182" cy="409.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
-<text x="172" y="400.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">1,201</text>
-<circle cx="513" cy="480.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
-<text x="523" y="471.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">116</text>
+<line x1="182.0" y1="205" x2="182.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="182.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000 patterns</text>
+<line x1="347.5" y1="205" x2="347.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="347.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000 patterns</text>
+<line x1="513.0" y1="205" x2="513.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="513.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000 patterns</text>
+<path d="M 182.0 246.0 L 347.5 270.9 L 513.0 286.0" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="246.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="172.0" y="237.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">259,421</text>
+<circle cx="347.5" cy="270.9" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="347.5" y="261.9" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">114,505</text>
+<circle cx="513.0" cy="286.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="523.0" y="277.0" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">69,634</text>
+<path d="M 182.0 426.0 L 347.5 442.6 L 513.0 454.7" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="426.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="172.0" y="417.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">696</text>
+<circle cx="347.5" cy="442.6" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="347.5" y="424.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">404</text>
+<circle cx="513.0" cy="454.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="523.0" y="445.7" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">271</text>
+<path d="M 182.0 390.0 L 347.5 438.1 L 513.0 459.8" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="390.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="172.0" y="381.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,277</text>
+<circle cx="347.5" cy="438.1" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="347.5" y="457.1" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">468</text>
+<circle cx="513.0" cy="459.8" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="523.0" y="450.8" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">229</text>
+<path d="M 182.0 409.4 L 347.5 455.7 L 513.0 480.4" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="409.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="172.0" y="400.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">1,201</text>
+<circle cx="347.5" cy="455.7" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="347.5" y="446.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">262</text>
+<circle cx="513.0" cy="480.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="523.0" y="471.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">116</text>
 <rect x="655" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
 <text x="892.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Mixed regex</text>
-<line x1="727" y1="205" x2="727" y2="625" stroke="#e8e4da" stroke-width="1"/>
-<text x="727" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000 patterns</text>
-<line x1="1058" y1="205" x2="1058" y2="625" stroke="#e8e4da" stroke-width="1"/>
-<text x="1058" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000 patterns</text>
-<path d="M 727 277.4 L 1058 357.4" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
-<circle cx="727" cy="277.4" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
-<text x="717" y="268.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">92,393</text>
-<circle cx="1058" cy="357.4" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
-<text x="1068" y="348.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">6,647</text>
-<path d="M 727 421.4 L 1058 441.1" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
-<circle cx="727" cy="421.4" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="717" y="412.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">811</text>
-<circle cx="1058" cy="441.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
-<text x="1068" y="432.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">423</text>
-<path d="M 727 390.5 L 1058 459.4" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
-<circle cx="727" cy="390.5" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
-<text x="717" y="381.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,237</text>
-<circle cx="1058" cy="459.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
-<text x="1068" y="450.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">232</text>
-<path d="M 727 424.1 L 1058 492.1" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
-<circle cx="727" cy="424.1" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
-<text x="717" y="415.1" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">741</text>
-<circle cx="1058" cy="492.1" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
-<text x="1068" y="483.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">79</text>
+<line x1="727.0" y1="205" x2="727.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="727.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000 patterns</text>
+<line x1="892.5" y1="205" x2="892.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="892.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000 patterns</text>
+<line x1="1058.0" y1="205" x2="1058.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="1058.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000 patterns</text>
+<path d="M 727.0 277.4 L 892.5 316.5 L 1058.0 357.4" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="277.4" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="717.0" y="268.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">92,393</text>
+<circle cx="892.5" cy="316.5" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="892.5" y="307.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">25,495</text>
+<circle cx="1058.0" cy="357.4" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="1068.0" y="348.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">6,647</text>
+<path d="M 727.0 421.4 L 892.5 435.9 L 1058.0 441.1" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="421.4" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="717.0" y="412.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">811</text>
+<circle cx="892.5" cy="435.9" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="892.5" y="417.9" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">503</text>
+<circle cx="1058.0" cy="441.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="1068.0" y="432.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">423</text>
+<path d="M 727.0 390.5 L 892.5 438.0 L 1058.0 459.4" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="390.5" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="717.0" y="381.5" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,237</text>
+<circle cx="892.5" cy="438.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="892.5" y="457.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">469</text>
+<circle cx="1058.0" cy="459.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="1068.0" y="450.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">232</text>
+<path d="M 727.0 424.1 L 892.5 469.4 L 1058.0 492.1" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="424.1" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="717.0" y="415.1" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">741</text>
+<circle cx="892.5" cy="469.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="892.5" y="460.4" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">167</text>
+<circle cx="1058.0" cy="492.1" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="1068.0" y="483.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">79</text>
 <text x="25" y="410" transform="rotate(-90 25 410)" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">Whole-task throughput (log scale)</text>
 </svg>


### PR DESCRIPTION
## Summary
- add measured 5,000-pattern points to the single front-page throughput chart
- calibrate each JVM engine independently on agogo rather than interpolate
- describe the workload-dependent 5K crossover and link all 24 winner receipts

## Evidence
- 68 calibration receipts retain worker sweeps, versions, host/container metadata, raw timings, and exact match validation
- final winners use 3 warm-ups and 9 measured scans
- SVG validated and visually inspected