### PR TITLE
Refresh README with five-point benchmark campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,32 @@ The public comparison model is:
 - rmatch: register the same pattern set in one matcher and scan the corpus once.
 
 Current measurements use byte-identical inputs and require match counts to
-agree before a timing is retained. The chart below comes from Docker runs on a
-16-core / 32-thread AMD Ryzen 9 9950X3D using deterministic 8 MiB fixtures with
-1,000, 5,000, and 10,000 patterns. Each JVM engine uses the highest-throughput
-worker count found in its calibration sweep. rmatch 1.9.6 uses two workers at
-1K and four at 5K and 10K. The per-pattern engines use heavier task
-oversubscription: their exact retained settings are recorded with the receipts.
-Hyperscan is the explicitly labeled one-thread native reference, included to
-show the much higher native-performance ceiling rather than as an
-execution-model peer.
+agree before a timing is retained. The charts below come from Docker runs on a
+16-core / 32-thread AMD Ryzen 9 9950X3D using deterministic 8 MiB and 50 MiB
+fixtures with 1,000, 2,500, 5,000, 7,500, and 10,000 patterns. Every JVM data
+point uses the highest-throughput thread count found for that engine and
+scenario in its calibration sweep. The exact thread counts are recorded with
+the receipts in the benchmark project. Hyperscan is the explicitly labeled
+one-thread native reference, included to show the much higher
+native-performance ceiling rather than as an execution-model peer.
 
-![Maximum retained throughput of Hyperscan, rmatch, RE2/J, and Java regex](docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg)
+![Maximum retained throughput on 8 MiB fixtures](docs/benchmark-plots/exploratory-2026-07-12/max-throughput-8m.svg)
 
-This is deliberately a “push each engine” comparison, not an equal-CPU-budget
-comparison. At 1K patterns tuned RE2/J leads the JVM lanes. At 5K the result is
-workload-dependent: RE2/J leads on diverse literals, while rmatch leads on the
-mixed-regex family. At 10K rmatch leads both retained RE2/J and Java lanes. The
-logarithmic scale keeps Hyperscan and the JVM results legible in one chart.
+![Maximum retained throughput on 50 MiB fixtures](docs/benchmark-plots/exploratory-2026-07-12/max-throughput-50m.svg)
+
+This is deliberately a "push each engine" comparison, not an equal-CPU-budget
+comparison. At 1,000 patterns tuned RE2/J leads the JVM lanes. As the pattern
+set grows, rmatch overtakes RE2/J between 5,000 and 7,500 patterns, depending
+on fixture size and expression family. The logarithmic scale keeps Hyperscan
+and the JVM results legible in the same chart.
 
 These are exploratory measurements from a benchmark project that is only just
 getting started, not a systematic testing campaign or a final verdict. The
 workloads are generated, the scenario set is still small, and wider syntax,
 corpora, machines, match densities, and resource controls remain to be tested.
-The harness, calibration sweeps, methodology, and all 24 winner receipts live
-in the [rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements/tree/main/receipts/agogo-2026-07-12-max-throughput).
+The harness, calibration sweeps, methodology, exact thread counts, and all 80
+retained receipts live in the
+[rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements#current-exploratory-evidence).
 Watch this space.
 
 Use rmatch when the workload looks like this:
@@ -64,10 +66,6 @@ Use rmatch when the workload looks like this:
   breadth.
 - You can work within a regular-language subset and do not need captures,
   backreferences, or lookaround.
-
-Do not use rmatch just because the API is pleasant. A convenient API is there
-to remove adoption friction; the reason to reach for this library is the
-many-pattern scaling profile.
 
 When contributing to rmatch development, performance regression testing is part
 of the work: almost all plausible matcher improvements are not improvements

--- a/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-10/four-engine-overview-log.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
 <title id="title">Maximum retained throughput by engine</title>
-<desc id="desc">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated winner</desc>
+<desc id="desc">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</desc>
 <rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
 <text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Maximum retained throughput by engine</text>
-<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated winner</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</text>
 <line x1="72" y1="138" x2="90" y2="138" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
 <circle cx="81" cy="138" r="4" fill="#f7f4ed" stroke="#087e8b" stroke-width="3"/>
 <text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T (native reference)</text>

--- a/docs/benchmark-plots/exploratory-2026-07-12/max-throughput-50m.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-12/max-throughput-50m.svg
@@ -1,0 +1,146 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+<title id="title">Maximum retained throughput by engine</title>
+<desc id="desc">Exploratory 50 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</desc>
+<rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
+<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Maximum retained throughput by engine</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 50 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</text>
+<line x1="72" y1="138" x2="90" y2="138" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
+<circle cx="81" cy="138" r="4" fill="#f7f4ed" stroke="#087e8b" stroke-width="3"/>
+<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T (native reference)</text>
+<line x1="351" y1="138" x2="369" y2="138" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
+<circle cx="360" cy="138" r="4" fill="#f7f4ed" stroke="#e4572e" stroke-width="3"/>
+<text x="376" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch tuned</text>
+<line x1="478" y1="138" x2="496" y2="138" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
+<circle cx="487" cy="138" r="4" fill="#f7f4ed" stroke="#6f95ca" stroke-width="3"/>
+<text x="503" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
+<line x1="597" y1="138" x2="615" y2="138" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
+<circle cx="606" cy="138" r="4" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="3"/>
+<text x="622" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex tuned</text>
+<line x1="110" y1="625.0" x2="1130" y2="625.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="630.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Mbit/s</text>
+<line x1="110" y1="555.0" x2="1130" y2="555.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="560.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Mbit/s</text>
+<line x1="110" y1="485.0" x2="1130" y2="485.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="490.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Mbit/s</text>
+<line x1="110" y1="415.0" x2="1130" y2="415.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="420.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Gbit/s</text>
+<line x1="110" y1="345.0" x2="1130" y2="345.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="350.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Gbit/s</text>
+<line x1="110" y1="275.0" x2="1130" y2="275.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="280.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Gbit/s</text>
+<line x1="110" y1="205.0" x2="1130" y2="205.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="210.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1000 Gbit/s</text>
+<rect x="110" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
+<text x="347.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Diverse literals</text>
+<line x1="182.0" y1="205" x2="182.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="182.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000</text>
+<line x1="264.75" y1="205" x2="264.75" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="264.75" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">2,500</text>
+<line x1="347.5" y1="205" x2="347.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="347.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000</text>
+<line x1="430.25" y1="205" x2="430.25" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="430.25" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">7,500</text>
+<line x1="513.0" y1="205" x2="513.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="513.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000</text>
+<path d="M 182.0 241.7 L 264.75 248.8 L 347.5 248.6 L 430.25 250.3 L 513.0 249.7" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="241.7" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="172.0" y="232.7" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">298,640</text>
+<circle cx="264.75" cy="248.8" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="264.75" y="239.8" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">236,912</text>
+<circle cx="347.5" cy="248.6" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="347.5" y="239.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">238,682</text>
+<circle cx="430.25" cy="250.3" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="430.25" y="241.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">225,646</text>
+<circle cx="513.0" cy="249.7" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="523.0" y="240.7" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">229,469</text>
+<path d="M 182.0 418.0 L 264.75 419.9 L 347.5 423.8 L 430.25 429.0 L 513.0 431.5" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="418.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="172.0" y="409.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">906</text>
+<circle cx="264.75" cy="419.9" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="264.75" y="403.9" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">852</text>
+<circle cx="347.5" cy="423.8" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="347.5" y="407.8" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">748</text>
+<circle cx="430.25" cy="429.0" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="430.25" y="413.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">631</text>
+<circle cx="513.0" cy="431.5" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="523.0" y="422.5" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">581</text>
+<path d="M 182.0 388.9 L 264.75 416.9 L 347.5 437.7 L 430.25 450.0 L 513.0 458.5" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="388.9" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="172.0" y="379.9" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,357</text>
+<circle cx="264.75" cy="416.9" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="264.75" y="434.9" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">941</text>
+<circle cx="347.5" cy="437.7" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="347.5" y="455.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">474</text>
+<circle cx="430.25" cy="450.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="430.25" y="468.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">316</text>
+<circle cx="513.0" cy="458.5" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="523.0" y="449.5" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">239</text>
+<path d="M 182.0 406.4 L 264.75 433.5 L 347.5 454.5 L 430.25 467.0 L 513.0 476.4" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="406.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="172.0" y="397.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">1,326</text>
+<circle cx="264.75" cy="433.5" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="264.75" y="446.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">544</text>
+<circle cx="347.5" cy="454.5" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="347.5" y="467.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">272</text>
+<circle cx="430.25" cy="467.0" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="430.25" y="480.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">181</text>
+<circle cx="513.0" cy="476.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="523.0" y="467.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">132</text>
+<rect x="655" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
+<text x="892.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Mixed regex</text>
+<line x1="727.0" y1="205" x2="727.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="727.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000</text>
+<line x1="809.75" y1="205" x2="809.75" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="809.75" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">2,500</text>
+<line x1="892.5" y1="205" x2="892.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="892.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000</text>
+<line x1="975.25" y1="205" x2="975.25" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="975.25" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">7,500</text>
+<line x1="1058.0" y1="205" x2="1058.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="1058.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000</text>
+<path d="M 727.0 254.2 L 809.75 256.6 L 892.5 272.7 L 975.25 290.7 L 1058.0 305.5" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="254.2" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="717.0" y="245.2" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">198,426</text>
+<circle cx="809.75" cy="256.6" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="809.75" y="247.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">183,058</text>
+<circle cx="892.5" cy="272.7" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="892.5" y="263.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">107,823</text>
+<circle cx="975.25" cy="290.7" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="975.25" y="281.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">59,636</text>
+<circle cx="1058.0" cy="305.5" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="1068.0" y="296.5" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">36,665</text>
+<path d="M 727.0 416.6 L 809.75 417.5 L 892.5 419.7 L 975.25 422.3 L 1058.0 426.1" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="416.6" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="717.0" y="407.6" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">948</text>
+<circle cx="809.75" cy="417.5" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="809.75" y="401.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">922</text>
+<circle cx="892.5" cy="419.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="892.5" y="403.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">858</text>
+<circle cx="975.25" cy="422.3" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="975.25" y="406.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">788</text>
+<circle cx="1058.0" cy="426.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="1068.0" y="417.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">693</text>
+<path d="M 727.0 389.2 L 809.75 416.5 L 892.5 437.8 L 975.25 450.4 L 1058.0 459.0" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="389.2" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="717.0" y="380.2" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,339</text>
+<circle cx="809.75" cy="416.5" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="809.75" y="434.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">950</text>
+<circle cx="892.5" cy="437.8" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="892.5" y="455.8" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">473</text>
+<circle cx="975.25" cy="450.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="975.25" y="468.4" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">312</text>
+<circle cx="1058.0" cy="459.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="1068.0" y="450.0" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">235</text>
+<path d="M 727.0 421.2 L 809.75 448.7 L 892.5 469.0 L 975.25 481.6 L 1058.0 490.3" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="421.2" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="717.0" y="412.2" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">817</text>
+<circle cx="809.75" cy="448.7" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="809.75" y="461.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">330</text>
+<circle cx="892.5" cy="469.0" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="892.5" y="482.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">169</text>
+<circle cx="975.25" cy="481.6" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="975.25" y="494.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">112</text>
+<circle cx="1058.0" cy="490.3" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="1068.0" y="481.3" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">84</text>
+<text x="25" y="410" transform="rotate(-90 25 410)" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">Whole-task throughput (log scale)</text>
+</svg>

--- a/docs/benchmark-plots/exploratory-2026-07-12/max-throughput-8m.svg
+++ b/docs/benchmark-plots/exploratory-2026-07-12/max-throughput-8m.svg
@@ -1,0 +1,146 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+<title id="title">Maximum retained throughput by engine</title>
+<desc id="desc">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</desc>
+<rect width="1200" height="720" rx="22" fill="#f7f4ed"/>
+<text x="72" y="66" font-family="Georgia, serif" font-size="34" font-weight="700" fill="#17212b">Maximum retained throughput by engine</text>
+<text x="72" y="98" font-family="Verdana, sans-serif" font-size="15" fill="#53606c">Exploratory 8 MiB fixtures on a 16-core / 32-thread AMD Ryzen 9 9950X3D; each JVM engine uses its calibrated thread count</text>
+<line x1="72" y1="138" x2="90" y2="138" stroke="#087e8b" stroke-width="4" stroke-linecap="round"/>
+<circle cx="81" cy="138" r="4" fill="#f7f4ed" stroke="#087e8b" stroke-width="3"/>
+<text x="97" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Hyperscan 1T (native reference)</text>
+<line x1="351" y1="138" x2="369" y2="138" stroke="#e4572e" stroke-width="4" stroke-linecap="round"/>
+<circle cx="360" cy="138" r="4" fill="#f7f4ed" stroke="#e4572e" stroke-width="3"/>
+<text x="376" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">rmatch tuned</text>
+<line x1="478" y1="138" x2="496" y2="138" stroke="#6f95ca" stroke-width="4" stroke-linecap="round"/>
+<circle cx="487" cy="138" r="4" fill="#f7f4ed" stroke="#6f95ca" stroke-width="3"/>
+<text x="503" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">RE2/J tuned</text>
+<line x1="597" y1="138" x2="615" y2="138" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round"/>
+<circle cx="606" cy="138" r="4" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="3"/>
+<text x="622" y="144" font-family="Verdana, sans-serif" font-size="14" fill="#27333d">Java regex tuned</text>
+<line x1="110" y1="625.0" x2="1130" y2="625.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="630.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Mbit/s</text>
+<line x1="110" y1="555.0" x2="1130" y2="555.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="560.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Mbit/s</text>
+<line x1="110" y1="485.0" x2="1130" y2="485.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="490.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Mbit/s</text>
+<line x1="110" y1="415.0" x2="1130" y2="415.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="420.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1 Gbit/s</text>
+<line x1="110" y1="345.0" x2="1130" y2="345.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="350.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">10 Gbit/s</text>
+<line x1="110" y1="275.0" x2="1130" y2="275.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="280.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">100 Gbit/s</text>
+<line x1="110" y1="205.0" x2="1130" y2="205.0" stroke="#d9d5ca" stroke-width="1"/>
+<text x="96" y="210.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="12" fill="#687580">1000 Gbit/s</text>
+<rect x="110" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
+<text x="347.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Diverse literals</text>
+<line x1="182.0" y1="205" x2="182.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="182.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000</text>
+<line x1="264.75" y1="205" x2="264.75" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="264.75" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">2,500</text>
+<line x1="347.5" y1="205" x2="347.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="347.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000</text>
+<line x1="430.25" y1="205" x2="430.25" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="430.25" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">7,500</text>
+<line x1="513.0" y1="205" x2="513.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="513.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000</text>
+<path d="M 182.0 246.8 L 264.75 252.8 L 347.5 272.0 L 430.25 281.3 L 513.0 289.1" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="246.8" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="172.0" y="237.8" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">252,932</text>
+<circle cx="264.75" cy="252.8" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="264.75" y="243.8" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">207,590</text>
+<circle cx="347.5" cy="272.0" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="347.5" y="263.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">110,373</text>
+<circle cx="430.25" cy="281.3" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="430.25" y="272.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">81,374</text>
+<circle cx="513.0" cy="289.1" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="523.0" y="280.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">62,861</text>
+<path d="M 182.0 428.4 L 264.75 431.2 L 347.5 442.3 L 430.25 449.7 L 513.0 454.3" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="428.4" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="172.0" y="419.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">643</text>
+<circle cx="264.75" cy="431.2" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="264.75" y="415.2" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">587</text>
+<circle cx="347.5" cy="442.3" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="347.5" y="426.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">407</text>
+<circle cx="430.25" cy="449.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="430.25" y="433.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">319</text>
+<circle cx="513.0" cy="454.3" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="523.0" y="445.3" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">274</text>
+<path d="M 182.0 391.0 L 264.75 416.4 L 347.5 438.2 L 430.25 450.2 L 513.0 459.4" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="391.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="172.0" y="382.0" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,205</text>
+<circle cx="264.75" cy="416.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="264.75" y="434.4" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">954</text>
+<circle cx="347.5" cy="438.2" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="347.5" y="456.2" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">466</text>
+<circle cx="430.25" cy="450.2" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="430.25" y="468.2" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">314</text>
+<circle cx="513.0" cy="459.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="523.0" y="450.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">232</text>
+<path d="M 182.0 411.8 L 264.75 434.3 L 347.5 455.5 L 430.25 468.6 L 513.0 479.3" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="182.0" cy="411.8" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="172.0" y="402.8" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">1,112</text>
+<circle cx="264.75" cy="434.3" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="264.75" y="447.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">530</text>
+<circle cx="347.5" cy="455.5" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="347.5" y="468.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">264</text>
+<circle cx="430.25" cy="468.6" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="430.25" y="481.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">171</text>
+<circle cx="513.0" cy="479.3" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="523.0" y="470.3" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">121</text>
+<rect x="655" y="205" width="475" height="420" rx="10" fill="none" stroke="#cfcabf"/>
+<text x="892.5" y="191" text-anchor="middle" font-family="Georgia, serif" font-size="20" font-weight="700" fill="#27333d">Mixed regex</text>
+<line x1="727.0" y1="205" x2="727.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="727.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">1,000</text>
+<line x1="809.75" y1="205" x2="809.75" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="809.75" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">2,500</text>
+<line x1="892.5" y1="205" x2="892.5" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="892.5" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">5,000</text>
+<line x1="975.25" y1="205" x2="975.25" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="975.25" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">7,500</text>
+<line x1="1058.0" y1="205" x2="1058.0" y2="625" stroke="#e8e4da" stroke-width="1"/>
+<text x="1058.0" y="651" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">10,000</text>
+<path d="M 727.0 265.8 L 809.75 289.5 L 892.5 316.3 L 975.25 335.6 L 1058.0 353.2" fill="none" stroke="#087e8b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="265.8" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="717.0" y="256.8" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">135,238</text>
+<circle cx="809.75" cy="289.5" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="809.75" y="280.5" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">62,142</text>
+<circle cx="892.5" cy="316.3" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="892.5" y="307.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">25,672</text>
+<circle cx="975.25" cy="335.6" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="975.25" y="326.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">13,617</text>
+<circle cx="1058.0" cy="353.2" r="6" fill="#f7f4ed" stroke="#087e8b" stroke-width="4"/>
+<text x="1068.0" y="344.2" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#087e8b">7,645</text>
+<path d="M 727.0 420.6 L 809.75 427.7 L 892.5 435.3 L 975.25 435.6 L 1058.0 441.1" fill="none" stroke="#e4572e" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="420.6" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="717.0" y="411.6" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">831</text>
+<circle cx="809.75" cy="427.7" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="809.75" y="411.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">658</text>
+<circle cx="892.5" cy="435.3" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="892.5" y="419.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">514</text>
+<circle cx="975.25" cy="435.6" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="975.25" y="419.6" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">508</text>
+<circle cx="1058.0" cy="441.1" r="6" fill="#f7f4ed" stroke="#e4572e" stroke-width="4"/>
+<text x="1068.0" y="432.1" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#e4572e">424</text>
+<path d="M 727.0 390.4 L 809.75 416.7 L 892.5 437.9 L 975.25 450.0 L 1058.0 459.4" fill="none" stroke="#6f95ca" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="390.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="717.0" y="381.4" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">2,247</text>
+<circle cx="809.75" cy="416.7" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="809.75" y="434.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">945</text>
+<circle cx="892.5" cy="437.9" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="892.5" y="455.9" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">471</text>
+<circle cx="975.25" cy="450.0" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="975.25" y="468.0" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">317</text>
+<circle cx="1058.0" cy="459.4" r="6" fill="#f7f4ed" stroke="#6f95ca" stroke-width="4"/>
+<text x="1068.0" y="450.4" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#6f95ca">232</text>
+<path d="M 727.0 423.9 L 809.75 448.3 L 892.5 469.4 L 975.25 479.7 L 1058.0 491.7" fill="none" stroke="#9a9fa6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="727.0" cy="423.9" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="717.0" y="414.9" text-anchor="end" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">745</text>
+<circle cx="809.75" cy="448.3" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="809.75" y="461.3" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">335</text>
+<circle cx="892.5" cy="469.4" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="892.5" y="482.4" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">167</text>
+<circle cx="975.25" cy="479.7" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="975.25" y="492.7" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">119</text>
+<circle cx="1058.0" cy="491.7" r="6" fill="#f7f4ed" stroke="#9a9fa6" stroke-width="4"/>
+<text x="1068.0" y="482.7" text-anchor="start" font-family="Verdana, sans-serif" font-size="10" fill="#9a9fa6">80</text>
+<text x="25" y="410" transform="rotate(-90 25 410)" text-anchor="middle" font-family="Verdana, sans-serif" font-size="13" fill="#53606c">Whole-task throughput (log scale)</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the three-point benchmark view with five-point 8 MiB and 50 MiB campaigns
- state explicitly that each JVM point uses a calibrated thread count
- link exact thread counts and all 80 validated receipts in the benchmark project
- remove the prescriptive API-vs-performance sentence

## Verification
- both SVG files parse as valid XML
- both campaigns contain 40 exact-match validated receipts
- benchmark plots regenerate from archived receipts
