### PR TITLE
Prepare 2.0 syntax docs and pre-RC gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## 1.9.7-SNAPSHOT - in development
 
 - Continue pre-2.0 stabilization after publishing `1.9.6`.
+- Drafted the `2.0.0-RC1` release notes and a normative syntax-and-semantics
+  reference, including the Java 21 baseline, supported language, deliberate
+  exclusions, longest-per-start matching, overlapping matches, and callback
+  behavior.
+- Added a repeatable Docker consumer gate covering Maven, Gradle, direct class
+  path use, and JPMS. All four modes pass against the current snapshot on the
+  high-core test host.
+- Ran the final pre-RC Docker regression matrix against published `1.9.6` over
+  eight 8 MiB and 50 MiB scenarios. Exact match validation passed throughout;
+  the observed range was 2.92% slower to 9.58% faster, within the agreed 3%
+  regression limit. Raw receipts are under
+  `docs/benchmark-receipts/2.0-pre-rc-2026-07-12/`.
 
 ## 1.9.6 - pre-2.0 Maven Central release candidate
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GATE_SKIP_REBUILD ?= 0
 .PHONY: help main main-local main-docker build test clean profile fmt spotless spotbugs javadocs release-central-javadoc-check
 .PHONY: perf-local-setup perf-local-smoke perf-local-baseline perf-local-candidate perf-docker-smoke
 .PHONY: gate-baseline gate-candidate
-.PHONY: release-central-preflight release-central-profile-check release-central-publish
+.PHONY: release-central-preflight release-central-profile-check release-central-publish release-consumer-smoke
 
 help: ## [core] Show available top-level targets
 	@echo "Top-level rmatch Make targets"
@@ -113,6 +113,9 @@ release-central-preflight: ## [core] Full non-performance regression check befor
 
 release-central-profile-check: ## [core] Verify Central release profile wiring without GPG signing
 	$(MVN) -q -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.skip=true verify
+
+release-consumer-smoke: ## [core] Test Maven, Gradle, classpath, and JPMS consumers in Docker
+	bash scripts/verify-consumers-docker.sh
 
 release-central-publish: ## [core] Publish parent+rmatch to Maven Central (requires token+GPG setup and non-SNAPSHOT version)
 	$(MVN) -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.skip=false deploy

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ is three methods: character lookup by position, substring lookup by half-open
 range, and a positional end-of-input probe — plus tolerance for concurrent
 readers.
 
-## Supported Syntax in 1.9.x
+## Supported Syntax
 
 The parser intentionally supports a reduced regular-expression language. This
 is not a drop-in replacement for `java.util.regex` or PCRE.
@@ -301,7 +301,7 @@ is not a drop-in replacement for `java.util.regex` or PCRE.
 
 ## Important Limitations
 
-These constructs are not part of the supported `1.9.x` surface:
+These constructs are not part of the supported surface:
 
 - Pure zero-width patterns such as `^$` are not yet part of the public support
   contract; match reporting currently assumes consumed spans.
@@ -311,17 +311,22 @@ These constructs are not part of the supported `1.9.x` surface:
 - `MULTILINE` mode and a non-DOTALL `.` toggle
 
 Backreferences are intentionally out of scope because they are non-regular.
-Other limitations are candidates for the 2.0 work, especially explicit mode
-semantics and pure zero-width match reporting.
+The normative 2.0 syntax and match-reporting contract, including longest-match
+and overlap behavior, is in
+[docs/regex-syntax-and-semantics.md](docs/regex-syntax-and-semantics.md).
 
 ## Release Notes and Roadmap
 
 - [CHANGELOG.md](CHANGELOG.md) describes the `1.9.x` pre-release line.
+- [docs/release-notes-2.0.0-RC1.md](docs/release-notes-2.0.0-RC1.md) is the
+  draft user-facing release note for the first 2.0 candidate.
+- [docs/regex-syntax-and-semantics.md](docs/regex-syntax-and-semantics.md)
+  defines the proposed stable syntax and matching behavior.
 - [docs/release.md](docs/release.md) documents the Maven Central release lane.
 - [docs/maven-central-release-checklist.md](docs/maven-central-release-checklist.md)
   tracks the current release checklist.
-- [docs/regex-syntax-roadmap.md](docs/regex-syntax-roadmap.md) tracks syntax
-  coverage toward `2.0.0`.
+- [docs/regex-syntax-roadmap.md](docs/regex-syntax-roadmap.md) tracks possible
+  work beyond the stable 2.0 surface.
 
 ## Repository Layout
 

--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>2.0-release-checklist</title>
+  <title>rmatch 2.0 release checklist</title>
   <style>
     /* Default styles provided by pandoc.
     ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
@@ -172,28 +172,32 @@
   </style>
 </head>
 <body>
+<header id="title-block-header">
+<h1 class="title">rmatch 2.0 release checklist</h1>
+</header>
 <h1 id="rmatch-2.0-release-checklist">rmatch 2.0 release checklist</h1>
 <p>This is the broad pre-2.0 checklist. It is intentionally
 over-inclusive: assume items here should be completed unless they are
 explicitly removed before the 2.0 release lane starts.</p>
 <h2 id="release-goal">Release Goal</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />State the 2.0 promise in one
-paragraph: what rmatch is for, what it is not for, and what
+<li><label><input type="checkbox" checked="" />State the 2.0 promise in
+one paragraph: what rmatch is for, what it is not for, and what
 compatibility promises start at 2.0.</label></li>
 <li><label><input type="checkbox" />Decide whether the last preview
 before 2.0 is <code>1.9.x</code>, <code>1.99.x</code>, or direct
 <code>2.0.0</code>.</label></li>
-<li><label><input type="checkbox" />Decide whether to cut
+<li><label><input type="checkbox" checked="" />Decide whether to cut
 <code>2.0.0-RC1</code> instead of using a <code>1.99.x</code> preview
 line.</label></li>
-<li><label><input type="checkbox" />Decide the exact Java baseline for
-2.0 and document it in README, Javadocs, POM metadata, and release
-notes.</label></li>
-<li><label><input type="checkbox" />State the 2.x compatibility promise
-explicitly: semantic versioning covers the exported root API plus
-documented matching behavior and syntax; unexported implementation
-packages are not compatibility contracts.</label></li>
+<li><label><input type="checkbox" checked="" />Decide the exact Java
+baseline for 2.0 and document it in README, Javadocs, POM metadata, and
+release notes.</label></li>
+<li><label><input type="checkbox" checked="" />State the 2.x
+compatibility promise explicitly: semantic versioning covers the
+exported root API plus documented matching behavior and syntax;
+unexported implementation packages are not compatibility
+contracts.</label></li>
 <li><label><input type="checkbox" />State the deprecation and removal
 policy for the 2.x line, including how much notice users receive before
 a public API is removed.</label></li>
@@ -408,14 +412,15 @@ leak into public Javadocs.</label></li>
 </ul>
 <h2 id="regex-syntax-contract">Regex Syntax Contract</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Freeze and document the 2.0
-supported syntax list.</label></li>
-<li><label><input type="checkbox" />Freeze and document deliberate
-exclusions: backreferences, captures, lookaround, or other
+<li><label><input type="checkbox" checked="" />Freeze and document the
+2.0 supported syntax list.</label></li>
+<li><label><input type="checkbox" checked="" />Freeze and document
+deliberate exclusions: backreferences, captures, lookaround, or other
 non-goals.</label></li>
-<li><label><input type="checkbox" />Verify line anchors <code>^</code>
-and <code>$</code> behavior with tests and documentation.</label></li>
-<li><label><input type="checkbox" />Verify word boundaries
+<li><label><input type="checkbox" checked="" />Verify line anchors
+<code>^</code> and <code>$</code> behavior with tests and
+documentation.</label></li>
+<li><label><input type="checkbox" checked="" />Verify word boundaries
 <code>\b</code> and <code>\B</code> behavior with tests and
 documentation.</label></li>
 <li><label><input type="checkbox" />Decide whether input anchors
@@ -477,10 +482,10 @@ baseline, expected to be Java 21 unless changed
 deliberately.</label></li>
 <li><label><input type="checkbox" />Run CI on a current newer Java
 version as well, such as Java 25 or 26.</label></li>
-<li><label><input type="checkbox" />Test the packaged candidate from
-clean external Maven and Gradle consumer projects, both on the class
-path and as a named JPMS module; do not rely only on reactor
-tests.</label></li>
+<li><label><input type="checkbox" checked="" />Test the packaged
+candidate from clean external Maven and Gradle consumer projects, both
+on the class path and as a named JPMS module; do not rely only on
+reactor tests.</label></li>
 <li><label><input type="checkbox" />Pin GitHub Actions dependencies to
 reviewed immutable commit SHAs, or document why a moving tag is
 deliberately accepted.</label></li>
@@ -497,10 +502,11 @@ so accidental 2.0.x breaking changes fail before release.</label></li>
 </ul>
 <h2 id="performance-gate">Performance Gate</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Run the standard Docker performance
-regression gate on the agreed high-core benchmark host.</label></li>
-<li><label><input type="checkbox" />Compare the 2.0 candidate against
-the latest published pre-2.0 release.</label></li>
+<li><label><input type="checkbox" checked="" />Run the standard Docker
+performance regression gate on the agreed high-core benchmark
+host.</label></li>
+<li><label><input type="checkbox" checked="" />Compare the 2.0 candidate
+against the latest published pre-2.0 release.</label></li>
 <li><label><input type="checkbox" />Compare rmatch against naive
 <code>java.util.regex</code> looping and RE2J looping using
 byte-identical corpora and pattern sets.</label></li>
@@ -515,18 +521,19 @@ parallel execution where each is material.</label></li>
 regex or RE2J wins as well as where rmatch wins, so the performance
 claim states a useful crossover rather than implying universal
 superiority.</label></li>
-<li><label><input type="checkbox" />Benchmark the packaged
+<li><label><input type="checkbox" checked="" />Benchmark the packaged
 release-candidate JAR through the public API, not only reactor classes
 or internal benchmark hooks.</label></li>
-<li><label><input type="checkbox" />Use deterministic benchmark inputs
-and record the generator settings.</label></li>
-<li><label><input type="checkbox" />Require equal match counts before
-comparing timings.</label></li>
-<li><label><input type="checkbox" />Fail the high-core regression gate
-on any slowdown above 3% unless the regression is explicitly understood,
-justified, and accepted before release.</label></li>
-<li><label><input type="checkbox" />Capture raw benchmark receipts,
-summaries, and charts in
+<li><label><input type="checkbox" checked="" />Use deterministic
+benchmark inputs and record the generator settings.</label></li>
+<li><label><input type="checkbox" checked="" />Require equal match
+counts before comparing timings.</label></li>
+<li><label><input type="checkbox" checked="" />Fail the high-core
+regression gate on any slowdown above 3% unless the regression is
+explicitly understood, justified, and accepted before
+release.</label></li>
+<li><label><input type="checkbox" checked="" />Capture raw benchmark
+receipts, summaries, and charts in
 <code>docs/benchmark-receipts/...</code>.</label></li>
 <li><label><input type="checkbox" />Update the README performance chart
 from a recent run of the current implementation.</label></li>
@@ -536,10 +543,10 @@ nickname.</label></li>
 <li><label><input type="checkbox" />Keep the developer performance
 regression protocol as a separate linked document, not a giant README
 section.</label></li>
-<li><label><input type="checkbox" />Investigate any material performance
-regression before release.</label></li>
-<li><label><input type="checkbox" />Record any material performance
-improvement in release notes, with receipts.</label></li>
+<li><label><input type="checkbox" checked="" />Investigate any material
+performance regression before release.</label></li>
+<li><label><input type="checkbox" checked="" />Record any material
+performance improvement in release notes, with receipts.</label></li>
 </ul>
 <h2 id="dependency-hygiene">Dependency Hygiene</h2>
 <ul class="task-list">
@@ -656,7 +663,7 @@ parse errors and pointing to
 <li><label><input type="checkbox" />Add a clear <code>1.x</code> to
 <code>2.0</code> migration section in
 <code>CHANGELOG.md</code>.</label></li>
-<li><label><input type="checkbox" />Publish a stable
+<li><label><input type="checkbox" checked="" />Publish a stable
 syntax-and-semantics reference separate from the README, including
 character/Unicode rules, match selection, exclusions, and
 examples.</label></li>
@@ -750,19 +757,20 @@ after the 2.0 release.</label></li>
 </ul>
 <h2 id="release-notes">Release Notes</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Write user-facing 2.0 release notes
-before publishing.</label></li>
-<li><label><input type="checkbox" />State the stable public API
+<li><label><input type="checkbox" checked="" />Write user-facing 2.0
+release notes before publishing.</label></li>
+<li><label><input type="checkbox" checked="" />State the stable public
+API surface.</label></li>
+<li><label><input type="checkbox" checked="" />State supported syntax
+and deliberate exclusions.</label></li>
+<li><label><input type="checkbox" checked="" />State Java
+baseline.</label></li>
+<li><label><input type="checkbox" checked="" />State dependency
 surface.</label></li>
-<li><label><input type="checkbox" />State supported syntax and
-deliberate exclusions.</label></li>
-<li><label><input type="checkbox" />State Java baseline.</label></li>
-<li><label><input type="checkbox" />State dependency
-surface.</label></li>
-<li><label><input type="checkbox" />State performance evidence with
-links to receipts.</label></li>
-<li><label><input type="checkbox" />State any known limitations
-honestly.</label></li>
+<li><label><input type="checkbox" checked="" />State performance
+evidence with links to receipts.</label></li>
+<li><label><input type="checkbox" checked="" />State any known
+limitations honestly.</label></li>
 <li><label><input type="checkbox" />State migration notes from
 <code>1.9.x</code>, including removed aliases such as
 <code>RMatch.buffer(String)</code> if applicable.</label></li>
@@ -771,8 +779,8 @@ final 2.0 API.</label></li>
 </ul>
 <h2 id="github-and-issue-hygiene">GitHub and Issue Hygiene</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Review open GitHub issues before
-release.</label></li>
+<li><label><input type="checkbox" checked="" />Review open GitHub issues
+before release.</label></li>
 <li><label><input type="checkbox" />Close issues that are fixed and
 verified.</label></li>
 <li><label><input type="checkbox" />Move non-blocking post-2.0 work to

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -6,15 +6,15 @@ items here should be completed unless they are explicitly removed before the
 
 ## Release Goal
 
-- [ ] State the 2.0 promise in one paragraph: what rmatch is for, what it is
+- [x] State the 2.0 promise in one paragraph: what rmatch is for, what it is
   not for, and what compatibility promises start at 2.0.
 - [ ] Decide whether the last preview before 2.0 is `1.9.x`, `1.99.x`, or
   direct `2.0.0`.
-- [ ] Decide whether to cut `2.0.0-RC1` instead of using a `1.99.x` preview
+- [x] Decide whether to cut `2.0.0-RC1` instead of using a `1.99.x` preview
   line.
-- [ ] Decide the exact Java baseline for 2.0 and document it in README,
+- [x] Decide the exact Java baseline for 2.0 and document it in README,
   Javadocs, POM metadata, and release notes.
-- [ ] State the 2.x compatibility promise explicitly: semantic versioning
+- [x] State the 2.x compatibility promise explicitly: semantic versioning
   covers the exported root API plus documented matching behavior and syntax;
   unexported implementation packages are not compatibility contracts.
 - [ ] State the deprecation and removal policy for the 2.x line, including how
@@ -165,11 +165,11 @@ items here should be completed unless they are explicitly removed before the
 
 ## Regex Syntax Contract
 
-- [ ] Freeze and document the 2.0 supported syntax list.
-- [ ] Freeze and document deliberate exclusions: backreferences, captures,
+- [x] Freeze and document the 2.0 supported syntax list.
+- [x] Freeze and document deliberate exclusions: backreferences, captures,
   lookaround, or other non-goals.
-- [ ] Verify line anchors `^` and `$` behavior with tests and documentation.
-- [ ] Verify word boundaries `\b` and `\B` behavior with tests and
+- [x] Verify line anchors `^` and `$` behavior with tests and documentation.
+- [x] Verify word boundaries `\b` and `\B` behavior with tests and
   documentation.
 - [ ] Decide whether input anchors `\A`, `\z`, or `\Z` are in or out for 2.0.
 - [ ] Decide whether pure zero-width match reporting is in or out for 2.0.
@@ -209,7 +209,7 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Run CI on the documented Java baseline, expected to be Java 21 unless
   changed deliberately.
 - [ ] Run CI on a current newer Java version as well, such as Java 25 or 26.
-- [ ] Test the packaged candidate from clean external Maven and Gradle consumer
+- [x] Test the packaged candidate from clean external Maven and Gradle consumer
   projects, both on the class path and as a named JPMS module; do not rely only
   on reactor tests.
 - [ ] Pin GitHub Actions dependencies to reviewed immutable commit SHAs, or
@@ -225,9 +225,9 @@ items here should be completed unless they are explicitly removed before the
 
 ## Performance Gate
 
-- [ ] Run the standard Docker performance regression gate on the agreed
+- [x] Run the standard Docker performance regression gate on the agreed
   high-core benchmark host.
-- [ ] Compare the 2.0 candidate against the latest published pre-2.0 release.
+- [x] Compare the 2.0 candidate against the latest published pre-2.0 release.
 - [ ] Compare rmatch against naive `java.util.regex` looping and RE2J looping
   using byte-identical corpora and pattern sets.
 - [ ] Publish a small benchmark matrix rather than one favorable workload:
@@ -238,13 +238,13 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Show representative cells where Java regex or RE2J wins as well as where
   rmatch wins, so the performance claim states a useful crossover rather than
   implying universal superiority.
-- [ ] Benchmark the packaged release-candidate JAR through the public API, not
+- [x] Benchmark the packaged release-candidate JAR through the public API, not
   only reactor classes or internal benchmark hooks.
-- [ ] Use deterministic benchmark inputs and record the generator settings.
-- [ ] Require equal match counts before comparing timings.
-- [ ] Fail the high-core regression gate on any slowdown above 3% unless the
+- [x] Use deterministic benchmark inputs and record the generator settings.
+- [x] Require equal match counts before comparing timings.
+- [x] Fail the high-core regression gate on any slowdown above 3% unless the
   regression is explicitly understood, justified, and accepted before release.
-- [ ] Capture raw benchmark receipts, summaries, and charts in
+- [x] Capture raw benchmark receipts, summaries, and charts in
   `docs/benchmark-receipts/...`.
 - [ ] Update the README performance chart from a recent run of the current
   implementation.
@@ -252,8 +252,8 @@ items here should be completed unless they are explicitly removed before the
   not by private machine nickname.
 - [ ] Keep the developer performance regression protocol as a separate linked
   document, not a giant README section.
-- [ ] Investigate any material performance regression before release.
-- [ ] Record any material performance improvement in release notes, with
+- [x] Investigate any material performance regression before release.
+- [x] Record any material performance improvement in release notes, with
   receipts.
 
 ## Dependency Hygiene
@@ -331,7 +331,7 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Add a README sentence explaining parse errors and pointing to
   `RegexpParserException`.
 - [ ] Add a clear `1.x` to `2.0` migration section in `CHANGELOG.md`.
-- [ ] Publish a stable syntax-and-semantics reference separate from the README,
+- [x] Publish a stable syntax-and-semantics reference separate from the README,
   including character/Unicode rules, match selection, exclusions, and examples.
 - [ ] Include package flattening, removed aliases and `remove()`, callback-offset
   decisions, build-then-use lifecycle changes, and buffer helper changes in
@@ -389,20 +389,20 @@ items here should be completed unless they are explicitly removed before the
 
 ## Release Notes
 
-- [ ] Write user-facing 2.0 release notes before publishing.
-- [ ] State the stable public API surface.
-- [ ] State supported syntax and deliberate exclusions.
-- [ ] State Java baseline.
-- [ ] State dependency surface.
-- [ ] State performance evidence with links to receipts.
-- [ ] State any known limitations honestly.
+- [x] Write user-facing 2.0 release notes before publishing.
+- [x] State the stable public API surface.
+- [x] State supported syntax and deliberate exclusions.
+- [x] State Java baseline.
+- [x] State dependency surface.
+- [x] State performance evidence with links to receipts.
+- [x] State any known limitations honestly.
 - [ ] State migration notes from `1.9.x`, including removed aliases such as
   `RMatch.buffer(String)` if applicable.
 - [ ] Include a short example using the final 2.0 API.
 
 ## GitHub and Issue Hygiene
 
-- [ ] Review open GitHub issues before release.
+- [x] Review open GitHub issues before release.
 - [ ] Close issues that are fixed and verified.
 - [ ] Move non-blocking post-2.0 work to clearly labeled future issues.
 - [ ] Ensure known blockers are either fixed or explicitly accepted.

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/README.md
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/README.md
@@ -1,0 +1,44 @@
+# 2.0 pre-RC regression gate
+
+This gate compared the published Maven Central release `no.rmz:rmatch:1.9.6`
+with commit `19d4d30adce740344a89939cda726e6dc4d3b7e5`, built as
+`1.9.7-SNAPSHOT`. Both artifacts ran in separate Java 21 Docker images on a
+16-core, 32-thread AMD Ryzen 9 9950X3D host.
+
+Each cell used the same deterministic scenario, worker-thread count, three
+warm-up scans, and nine measured scans. Throughput is whole-task Mbit/s.
+
+| Scenario | Threads | 1.9.6 | Candidate | Change |
+|---|---:|---:|---:|---:|
+| Diverse literals, 5,000, 8 MiB | 4 | 422.1 | 417.7 | -1.06% |
+| Diverse literals, 10,000, 8 MiB | 4 | 265.9 | 267.1 | +0.45% |
+| Mixed regex, 5,000, 8 MiB | 4 | 494.9 | 504.8 | +2.00% |
+| Mixed regex, 10,000, 8 MiB | 4 | 438.2 | 425.4 | -2.92% |
+| Diverse literals, 5,000, 50 MiB | 2 | 692.4 | 758.7 | +9.58% |
+| Diverse literals, 10,000, 50 MiB | 1 | 569.3 | 561.9 | -1.29% |
+| Mixed regex, 5,000, 50 MiB | 1 | 858.6 | 871.1 | +1.46% |
+| Mixed regex, 10,000, 50 MiB | 1 | 688.6 | 706.0 | +2.53% |
+
+All 16 receipts pass exact match-count validation. The largest retained
+slowdown is 2.92%, inside the agreed 3% pre-release limit. The largest speedup
+is 9.58%. This gate therefore passes without hiding the near-threshold 10,000
+mixed-regex, 8 MiB result.
+
+The adjacent JSON files are the unmodified benchmark receipts. They record
+engine version, container image, host metadata, input hashes, timing samples,
+thread count, and expected and observed matches.
+
+## Consumer compatibility on the same host
+
+The candidate also passed `make release-consumer-smoke` on the same host. The
+Docker harness installed the candidate into an isolated Maven repository and
+then compiled and ran four independent consumers under Java 21:
+
+- Maven dependency on the class path
+- Gradle dependency on the class path
+- direct `javac` and `java -cp`
+- direct `javac` and `java` as a named JPMS module requiring `no.rmz.rmatch`
+
+Every consumer reported exactly two expected matches. The repeatable harness
+is `scripts/verify-consumers-docker.sh`.
+

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-50m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-50m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-10000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "6c672cc89036e9a92ebdc920086aaebee6b5bfc1e591a384a0b19a48b3b2a015"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "00e94caa8c714fc9d7795bfdce1806825d8328835865ebd3450bf8425a9e6087"
+    },
+    "patterns.hs": {
+      "bytes": 308894,
+      "sha256": "b2d7ecde647cc16cb5de82a9f9a37573e48c84b7b360e157b9cf485af8c17c19"
+    },
+    "patterns.tsv": {
+      "bytes": 288894,
+      "sha256": "ce94f5d6809ee80a3ea6cfe0fa9b671ee9af2eac3b969d8480626233437d2ecb"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 20000,
+    "median_scan_ns": 736738713,
+    "mode": "1",
+    "prepare_ns": 75856760,
+    "scan_ns": [
+      753775720,
+      743916220,
+      728908988,
+      736738713,
+      736329196,
+      740321365,
+      739243569,
+      731242509,
+      733485978
+    ],
+    "throughput_mbit_per_second": 569.306855,
+    "warmup_ns": [
+      2036187965,
+      1015673201,
+      855785222
+    ]
+  },
+  "process_wall_seconds": 10.952975,
+  "repeats": 9,
+  "run_id": "e3bc50a9-ad49-45a7-b183-6a1db701c9c1",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "diverse-literals-10000-50m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":75856760,\"warmup_ns\":[2036187965, 1015673201, 855785222],\"scan_ns\":[753775720, 743916220, 728908988, 736738713, 736329196, 740321365, 739243569, 731242509, 733485978],\"median_scan_ns\":736738713,\"throughput_mbit_per_second\":569.306855,\"matches_per_iteration\":20000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:26.522684+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 20000,
+    "observed_matches_per_iteration": 20000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-50m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-50m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-10000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "6c672cc89036e9a92ebdc920086aaebee6b5bfc1e591a384a0b19a48b3b2a015"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "00e94caa8c714fc9d7795bfdce1806825d8328835865ebd3450bf8425a9e6087"
+    },
+    "patterns.hs": {
+      "bytes": 308894,
+      "sha256": "b2d7ecde647cc16cb5de82a9f9a37573e48c84b7b360e157b9cf485af8c17c19"
+    },
+    "patterns.tsv": {
+      "bytes": 288894,
+      "sha256": "ce94f5d6809ee80a3ea6cfe0fa9b671ee9af2eac3b969d8480626233437d2ecb"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 20000,
+    "median_scan_ns": 746395056,
+    "mode": "1",
+    "prepare_ns": 77023014,
+    "scan_ns": [
+      822178737,
+      743496925,
+      739930353,
+      741120201,
+      734357092,
+      751607253,
+      746395056,
+      747498251,
+      747286509
+    ],
+    "throughput_mbit_per_second": 561.941557,
+    "warmup_ns": [
+      2073987690,
+      1081013795,
+      775039240
+    ]
+  },
+  "process_wall_seconds": 11.088815,
+  "repeats": 9,
+  "run_id": "8017d79e-ec16-43d6-b7b4-d0866f1a0975",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "diverse-literals-10000-50m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":77023014,\"warmup_ns\":[2073987690, 1081013795, 775039240],\"scan_ns\":[822178737, 743496925, 739930353, 741120201, 734357092, 751607253, 746395056, 747498251, 747286509],\"median_scan_ns\":746395056,\"throughput_mbit_per_second\":561.941557,\"matches_per_iteration\":20000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:37.842859+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 20000,
+    "observed_matches_per_iteration": 20000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-8m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-8m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-10000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "ced159da9fc8f8625fb3220570f27b54cf26ba93441dac59e3c39230063e10ae"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "1c2b76e3dd65a14095b344fb2cac7ab47320abc8c6bbd86a1034f2f2079db6da"
+    },
+    "patterns.hs": {
+      "bytes": 308894,
+      "sha256": "b2d7ecde647cc16cb5de82a9f9a37573e48c84b7b360e157b9cf485af8c17c19"
+    },
+    "patterns.tsv": {
+      "bytes": 288894,
+      "sha256": "ce94f5d6809ee80a3ea6cfe0fa9b671ee9af2eac3b969d8480626233437d2ecb"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 20000,
+    "median_scan_ns": 252406803,
+    "mode": "4",
+    "prepare_ns": 76845477,
+    "scan_ns": [
+      313481187,
+      302261897,
+      241169689,
+      252406803,
+      248762885,
+      242273805,
+      260097725,
+      242923448,
+      253727982
+    ],
+    "throughput_mbit_per_second": 265.875813,
+    "warmup_ns": [
+      899505038,
+      388720275,
+      346243640
+    ]
+  },
+  "process_wall_seconds": 4.450157,
+  "repeats": 9,
+  "run_id": "e39ff7e3-5a46-4b26-a81b-e4cd4b926807",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "diverse-literals-10000-8m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":76845477,\"warmup_ns\":[899505038, 388720275, 346243640],\"scan_ns\":[313481187, 302261897, 241169689, 252406803, 248762885, 242273805, 260097725, 242923448, 253727982],\"median_scan_ns\":252406803,\"throughput_mbit_per_second\":265.875813,\"matches_per_iteration\":20000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:40.890551+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 20000,
+    "observed_matches_per_iteration": 20000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-8m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-10000-8m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-10000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "ced159da9fc8f8625fb3220570f27b54cf26ba93441dac59e3c39230063e10ae"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "1c2b76e3dd65a14095b344fb2cac7ab47320abc8c6bbd86a1034f2f2079db6da"
+    },
+    "patterns.hs": {
+      "bytes": 308894,
+      "sha256": "b2d7ecde647cc16cb5de82a9f9a37573e48c84b7b360e157b9cf485af8c17c19"
+    },
+    "patterns.tsv": {
+      "bytes": 288894,
+      "sha256": "ce94f5d6809ee80a3ea6cfe0fa9b671ee9af2eac3b969d8480626233437d2ecb"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 20000,
+    "median_scan_ns": 251269074,
+    "mode": "4",
+    "prepare_ns": 83688569,
+    "scan_ns": [
+      388044301,
+      242264257,
+      251269074,
+      241452476,
+      257769875,
+      246484109,
+      273436139,
+      243361100,
+      259668210
+    ],
+    "throughput_mbit_per_second": 267.07968,
+    "warmup_ns": [
+      970575049,
+      383723247,
+      257800474
+    ]
+  },
+  "process_wall_seconds": 4.464202,
+  "repeats": 9,
+  "run_id": "9fd74ddc-773d-475f-a1f2-854f696c3dcb",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "diverse-literals-10000-8m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":83688569,\"warmup_ns\":[970575049, 383723247, 257800474],\"scan_ns\":[388044301, 242264257, 251269074, 241452476, 257769875, 246484109, 273436139, 243361100, 259668210],\"median_scan_ns\":251269074,\"throughput_mbit_per_second\":267.079680,\"matches_per_iteration\":20000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:45.478633+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 20000,
+    "observed_matches_per_iteration": 20000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-50m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-50m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-5000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "2"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 2,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "4e306af007e05e43cb6666d9ad777736c07e383bc09f1c80f452e86a924a0632"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "ddb2904bcdcbb39f2e576725f1538268d6b5f5a23d3663f6c89cb30d0b1a81a7"
+    },
+    "patterns.hs": {
+      "bytes": 153893,
+      "sha256": "c9044b41ba096f1d57aa4e306435483799670b6fceb6e7186762cbe534015585"
+    },
+    "patterns.tsv": {
+      "bytes": 143893,
+      "sha256": "6d477fe99d0fd1c53e5711bcdc3f4d54f8c6e048110e442ecb67b5d1b6e70194"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 605791260,
+    "mode": "2",
+    "prepare_ns": 56045446,
+    "scan_ns": [
+      601656019,
+      607649659,
+      613079948,
+      623830529,
+      617246900,
+      605791260,
+      578462674,
+      593182862,
+      588830679
+    ],
+    "throughput_mbit_per_second": 692.367863,
+    "warmup_ns": [
+      1430944325,
+      652602956,
+      619111299
+    ]
+  },
+  "process_wall_seconds": 8.49027,
+  "repeats": 9,
+  "run_id": "31d5c24c-4000-4a6c-b8b8-beccbfd15cbd",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "diverse-literals-5000-50m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":56045446,\"warmup_ns\":[1430944325, 652602956, 619111299],\"scan_ns\":[601656019, 607649659, 613079948, 623830529, 617246900, 605791260, 578462674, 593182862, 588830679],\"median_scan_ns\":605791260,\"throughput_mbit_per_second\":692.367863,\"matches_per_iteration\":10000,\"mode\":\"2\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:07.115184+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-50m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-50m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-5000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "2"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 2,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "4e306af007e05e43cb6666d9ad777736c07e383bc09f1c80f452e86a924a0632"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "ddb2904bcdcbb39f2e576725f1538268d6b5f5a23d3663f6c89cb30d0b1a81a7"
+    },
+    "patterns.hs": {
+      "bytes": 153893,
+      "sha256": "c9044b41ba096f1d57aa4e306435483799670b6fceb6e7186762cbe534015585"
+    },
+    "patterns.tsv": {
+      "bytes": 143893,
+      "sha256": "6d477fe99d0fd1c53e5711bcdc3f4d54f8c6e048110e442ecb67b5d1b6e70194"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 552812676,
+    "mode": "2",
+    "prepare_ns": 55753302,
+    "scan_ns": [
+      553391324,
+      569395039,
+      577475691,
+      579968043,
+      546424336,
+      552812676,
+      545898529,
+      536403572,
+      541658609
+    ],
+    "throughput_mbit_per_second": 758.720663,
+    "warmup_ns": [
+      1322705686,
+      718033631,
+      584393224
+    ]
+  },
+  "process_wall_seconds": 8.009077,
+  "repeats": 9,
+  "run_id": "86f490b1-a892-4787-b2fb-aecd008a6b44",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "diverse-literals-5000-50m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":55753302,\"warmup_ns\":[1322705686, 718033631, 584393224],\"scan_ns\":[553391324, 569395039, 577475691, 579968043, 546424336, 552812676, 545898529, 536403572, 541658609],\"median_scan_ns\":552812676,\"throughput_mbit_per_second\":758.720663,\"matches_per_iteration\":10000,\"mode\":\"2\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:15.347939+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-8m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-8m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-5000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "6c481132b5fb2fe75bfbdd973ee034baa8681918730dce657888fd8df9c8d1f2"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "76a6f18ef0380d8fbbaaa9f68e0e5016f026aad02cb3efb09c652c7231e8cd50"
+    },
+    "patterns.hs": {
+      "bytes": 153893,
+      "sha256": "c9044b41ba096f1d57aa4e306435483799670b6fceb6e7186762cbe534015585"
+    },
+    "patterns.tsv": {
+      "bytes": 143893,
+      "sha256": "6d477fe99d0fd1c53e5711bcdc3f4d54f8c6e048110e442ecb67b5d1b6e70194"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 158972532,
+    "mode": "4",
+    "prepare_ns": 55797565,
+    "scan_ns": [
+      205082965,
+      158972532,
+      163440925,
+      154789890,
+      165552183,
+      155422692,
+      163421057,
+      153607927,
+      154922402
+    ],
+    "throughput_mbit_per_second": 422.141254,
+    "warmup_ns": [
+      636767621,
+      255775189,
+      266906221
+    ]
+  },
+  "process_wall_seconds": 3.017059,
+  "repeats": 9,
+  "run_id": "b4bd01c9-bd61-4270-abff-05c2fa0f7453",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "diverse-literals-5000-8m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":55797565,\"warmup_ns\":[636767621, 255775189, 266906221],\"scan_ns\":[205082965, 158972532, 163440925, 154789890, 165552183, 155422692, 163421057, 153607927, 154922402],\"median_scan_ns\":158972532,\"throughput_mbit_per_second\":422.141254,\"matches_per_iteration\":10000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:33.023888+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-8m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/diverse-literals-5000-8m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/diverse-literals-5000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "6c481132b5fb2fe75bfbdd973ee034baa8681918730dce657888fd8df9c8d1f2"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "76a6f18ef0380d8fbbaaa9f68e0e5016f026aad02cb3efb09c652c7231e8cd50"
+    },
+    "patterns.hs": {
+      "bytes": 153893,
+      "sha256": "c9044b41ba096f1d57aa4e306435483799670b6fceb6e7186762cbe534015585"
+    },
+    "patterns.tsv": {
+      "bytes": 143893,
+      "sha256": "6d477fe99d0fd1c53e5711bcdc3f4d54f8c6e048110e442ecb67b5d1b6e70194"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 160674262,
+    "mode": "4",
+    "prepare_ns": 60261010,
+    "scan_ns": [
+      233309415,
+      160674262,
+      167813676,
+      155880441,
+      167832803,
+      159016585,
+      172115454,
+      159529819,
+      160603167
+    ],
+    "throughput_mbit_per_second": 417.67028,
+    "warmup_ns": [
+      700913096,
+      285067201,
+      278722165
+    ]
+  },
+  "process_wall_seconds": 3.191233,
+  "repeats": 9,
+  "run_id": "c6a6589a-8f92-4a3a-b981-9fffa919f1b5",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "diverse-literals-5000-8m",
+    "kind": "diverse_literals",
+    "matches_per_pattern": 2,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":60261010,\"warmup_ns\":[700913096, 285067201, 278722165],\"scan_ns\":[233309415, 160674262, 167813676, 155880441, 167832803, 159016585, 172115454, 159529819, 160603167],\"median_scan_ns\":160674262,\"throughput_mbit_per_second\":417.670280,\"matches_per_iteration\":10000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:36.324568+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-50m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-50m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-10000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "064400914de51f71560baf45471eadb344b3739ff924808e702bdf56386bc04a"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "1f6edcfc45c862c09fbec114739b7bdc2c82980a49e092dd94aca00fbf29c27c"
+    },
+    "patterns.hs": {
+      "bytes": 298894,
+      "sha256": "5966f3e5ccfb457b927f284f4818d1a2604a95dd878cbf0fdc68ced492430a61"
+    },
+    "patterns.tsv": {
+      "bytes": 278894,
+      "sha256": "409d2d1718936d782d7548b8e13dc686b6a4e01d2c266287310c29fddf4e333d"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 609115091,
+    "mode": "1",
+    "prepare_ns": 95075989,
+    "scan_ns": [
+      629354426,
+      610571997,
+      599868305,
+      603334235,
+      609115091,
+      613737396,
+      611246397,
+      606955540,
+      597515077
+    ],
+    "throughput_mbit_per_second": 688.589736,
+    "warmup_ns": [
+      2104494049,
+      930053997,
+      734768203
+    ]
+  },
+  "process_wall_seconds": 9.648893,
+  "repeats": 9,
+  "run_id": "2007a248-68ae-4a54-80aa-f39f05370e93",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "mixed-regex-10000-50m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":95075989,\"warmup_ns\":[2104494049, 930053997, 734768203],\"scan_ns\":[629354426, 610571997, 599868305, 603334235, 609115091, 613737396, 611246397, 606955540, 597515077],\"median_scan_ns\":609115091,\"throughput_mbit_per_second\":688.589736,\"matches_per_iteration\":10000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:03:02.914164+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-50m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-50m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-10000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "064400914de51f71560baf45471eadb344b3739ff924808e702bdf56386bc04a"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "1f6edcfc45c862c09fbec114739b7bdc2c82980a49e092dd94aca00fbf29c27c"
+    },
+    "patterns.hs": {
+      "bytes": 298894,
+      "sha256": "5966f3e5ccfb457b927f284f4818d1a2604a95dd878cbf0fdc68ced492430a61"
+    },
+    "patterns.tsv": {
+      "bytes": 278894,
+      "sha256": "409d2d1718936d782d7548b8e13dc686b6a4e01d2c266287310c29fddf4e333d"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 594101717,
+    "mode": "1",
+    "prepare_ns": 88863714,
+    "scan_ns": [
+      592465350,
+      601147603,
+      588281927,
+      592214042,
+      591721317,
+      594101717,
+      595289652,
+      601558023,
+      595976897
+    ],
+    "throughput_mbit_per_second": 705.99089,
+    "warmup_ns": [
+      2201662761,
+      689668357,
+      861682779
+    ]
+  },
+  "process_wall_seconds": 9.52084,
+  "repeats": 9,
+  "run_id": "92e955d8-b014-4b17-8984-2db6ed9cbf36",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "mixed-regex-10000-50m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":88863714,\"warmup_ns\":[2201662761, 689668357, 861682779],\"scan_ns\":[592465350, 601147603, 588281927, 592214042, 591721317, 594101717, 595289652, 601558023, 595976897],\"median_scan_ns\":594101717,\"throughput_mbit_per_second\":705.990890,\"matches_per_iteration\":10000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:03:12.655280+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-8m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-8m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-10000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "2a785beda877721b40f402dbf13eae1e5c9990fd6af89ee93632cfbb0f96ed78"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "ef132e1b63598251bcfb7a11e55c503c01d658db69c6771562a10d1d9f91cea6"
+    },
+    "patterns.hs": {
+      "bytes": 298894,
+      "sha256": "5966f3e5ccfb457b927f284f4818d1a2604a95dd878cbf0fdc68ced492430a61"
+    },
+    "patterns.tsv": {
+      "bytes": 278894,
+      "sha256": "409d2d1718936d782d7548b8e13dc686b6a4e01d2c266287310c29fddf4e333d"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 153157741,
+    "mode": "4",
+    "prepare_ns": 91999198,
+    "scan_ns": [
+      251880855,
+      265334958,
+      152252784,
+      161964161,
+      153157741,
+      152155058,
+      161695561,
+      151145070,
+      151349769
+    ],
+    "throughput_mbit_per_second": 438.16828,
+    "warmup_ns": [
+      816023141,
+      246025248,
+      263772191
+    ]
+  },
+  "process_wall_seconds": 3.41708,
+  "repeats": 9,
+  "run_id": "858e4349-3fc5-4d84-8338-532bdc87059d",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "mixed-regex-10000-8m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":91999198,\"warmup_ns\":[816023141, 246025248, 263772191],\"scan_ns\":[251880855, 265334958, 152252784, 161964161, 153157741, 152155058, 161695561, 151145070, 151349769],\"median_scan_ns\":153157741,\"throughput_mbit_per_second\":438.168280,\"matches_per_iteration\":10000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:54.924170+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-8m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-10000-8m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-10000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "2a785beda877721b40f402dbf13eae1e5c9990fd6af89ee93632cfbb0f96ed78"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "ef132e1b63598251bcfb7a11e55c503c01d658db69c6771562a10d1d9f91cea6"
+    },
+    "patterns.hs": {
+      "bytes": 298894,
+      "sha256": "5966f3e5ccfb457b927f284f4818d1a2604a95dd878cbf0fdc68ced492430a61"
+    },
+    "patterns.tsv": {
+      "bytes": 278894,
+      "sha256": "409d2d1718936d782d7548b8e13dc686b6a4e01d2c266287310c29fddf4e333d"
+    }
+  },
+  "metrics": {
+    "expression_count": 10000,
+    "matches_per_iteration": 10000,
+    "median_scan_ns": 157769757,
+    "mode": "4",
+    "prepare_ns": 95139259,
+    "scan_ns": [
+      260521179,
+      230502056,
+      154673078,
+      160072750,
+      146937733,
+      150887712,
+      157769757,
+      150004144,
+      162095090
+    ],
+    "throughput_mbit_per_second": 425.359494,
+    "warmup_ns": [
+      761885176,
+      249758325,
+      289301391
+    ]
+  },
+  "process_wall_seconds": 3.36365,
+  "repeats": 9,
+  "run_id": "59727770-0ad2-4880-97f6-144a43429e83",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "mixed-regex-10000-8m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 10000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":10000,\"prepare_ns\":95139259,\"warmup_ns\":[761885176, 249758325, 289301391],\"scan_ns\":[260521179, 230502056, 154673078, 160072750, 146937733, 150887712, 157769757, 150004144, 162095090],\"median_scan_ns\":157769757,\"throughput_mbit_per_second\":425.359494,\"matches_per_iteration\":10000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:58.399844+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 10000,
+    "observed_matches_per_iteration": 10000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-50m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-50m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-5000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "94b71613eeb64b57c4359687204d5e0e0e7bcf0232667d2fe2e822656ce35466"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "a08a227c89965fbe7342ca2898b4e4069c1de8c41abb11bd81be7068b14a89a6"
+    },
+    "patterns.hs": {
+      "bytes": 148893,
+      "sha256": "36603ec2b0a6535749294cbfeb4d2ad5701fa4f9f06d59c5723fa6298add3085"
+    },
+    "patterns.tsv": {
+      "bytes": 138893,
+      "sha256": "491b0c91a9fa3f23123dd007a4caa8ad13bc47708edf68e140892d104e3c6db5"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 5000,
+    "median_scan_ns": 488528709,
+    "mode": "1",
+    "prepare_ns": 61424088,
+    "scan_ns": [
+      480072483,
+      488528709,
+      496049036,
+      490041961,
+      486858037,
+      486169890,
+      504481315,
+      491062128,
+      486708964
+    ],
+    "throughput_mbit_per_second": 858.558345,
+    "warmup_ns": [
+      1299545645,
+      822103645,
+      510647803
+    ]
+  },
+  "process_wall_seconds": 7.380202,
+  "repeats": 9,
+  "run_id": "02283f87-d02a-414a-967c-13808f0eb1a5",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "mixed-regex-5000-50m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":61424088,\"warmup_ns\":[1299545645, 822103645, 510647803],\"scan_ns\":[480072483, 488528709, 496049036, 490041961, 486858037, 486169890, 504481315, 491062128, 486708964],\"median_scan_ns\":488528709,\"throughput_mbit_per_second\":858.558345,\"matches_per_iteration\":5000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:45.440127+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 5000,
+    "observed_matches_per_iteration": 5000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-50m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-50m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-5000-50m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "1"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 1,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 52428800,
+      "sha256": "94b71613eeb64b57c4359687204d5e0e0e7bcf0232667d2fe2e822656ce35466"
+    },
+    "corpus.db": {
+      "bytes": 52486144,
+      "sha256": "a08a227c89965fbe7342ca2898b4e4069c1de8c41abb11bd81be7068b14a89a6"
+    },
+    "patterns.hs": {
+      "bytes": 148893,
+      "sha256": "36603ec2b0a6535749294cbfeb4d2ad5701fa4f9f06d59c5723fa6298add3085"
+    },
+    "patterns.tsv": {
+      "bytes": 138893,
+      "sha256": "491b0c91a9fa3f23123dd007a4caa8ad13bc47708edf68e140892d104e3c6db5"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 5000,
+    "median_scan_ns": 481486518,
+    "mode": "1",
+    "prepare_ns": 62476096,
+    "scan_ns": [
+      496218568,
+      504354986,
+      497640007,
+      481486518,
+      475205052,
+      614783142,
+      469216152,
+      471335626,
+      472253939
+    ],
+    "throughput_mbit_per_second": 871.115565,
+    "warmup_ns": [
+      1343278234,
+      725195538,
+      504662359
+    ]
+  },
+  "process_wall_seconds": 7.39041,
+  "repeats": 9,
+  "run_id": "da5cce36-eb29-4c98-a351-8ea97784fe53",
+  "scenario": {
+    "corpus_size_bytes": 52428800,
+    "id": "mixed-regex-5000-50m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":62476096,\"warmup_ns\":[1343278234, 725195538, 504662359],\"scan_ns\":[496218568, 504354986, 497640007, 481486518, 475205052, 614783142, 469216152, 471335626, 472253939],\"median_scan_ns\":481486518,\"throughput_mbit_per_second\":871.115565,\"matches_per_iteration\":5000,\"mode\":\"1\"}\n",
+  "timestamp_utc": "2026-07-12T21:02:53.040950+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 5000,
+    "observed_matches_per_iteration": 5000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-8m--rmatch-1.9.6.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-8m--rmatch-1.9.6.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-5000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.6",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:68e7718a5f93c979d9e961327222d5b16f0c3f7b246913ba4ff6f5d555047b1d",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.6",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.6"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "ce423a8fa2cc194238856f0b8b1dcdcce1610301b00ed9e77d16093ba0ecc15a"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "3abf7eddc8b77964cc77a186fae22ad81b2c05e6b94e0ac98b43893172d6da18"
+    },
+    "patterns.hs": {
+      "bytes": 148893,
+      "sha256": "36603ec2b0a6535749294cbfeb4d2ad5701fa4f9f06d59c5723fa6298add3085"
+    },
+    "patterns.tsv": {
+      "bytes": 138893,
+      "sha256": "491b0c91a9fa3f23123dd007a4caa8ad13bc47708edf68e140892d104e3c6db5"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 5000,
+    "median_scan_ns": 135595358,
+    "mode": "4",
+    "prepare_ns": 66189616,
+    "scan_ns": [
+      243631573,
+      138246471,
+      130556081,
+      135595358,
+      131008309,
+      146091787,
+      132945978,
+      136717158,
+      127778607
+    ],
+    "throughput_mbit_per_second": 494.920069,
+    "warmup_ns": [
+      764613516,
+      279274113,
+      185768786
+    ]
+  },
+  "process_wall_seconds": 2.962636,
+  "repeats": 9,
+  "run_id": "d49125ed-cbc8-4dbd-9f90-a0c9ee09d639",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "mixed-regex-5000-8m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":66189616,\"warmup_ns\":[764613516, 279274113, 185768786],\"scan_ns\":[243631573, 138246471, 130556081, 135595358, 131008309, 146091787, 132945978, 136717158, 127778607],\"median_scan_ns\":135595358,\"throughput_mbit_per_second\":494.920069,\"matches_per_iteration\":5000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:48.550501+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 5000,
+    "observed_matches_per_iteration": 5000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-8m--rmatch-1.9.7-SNAPSHOT.json
+++ b/docs/benchmark-receipts/2.0-pre-rc-2026-07-12/mixed-regex-5000-8m--rmatch-1.9.7-SNAPSHOT.json
@@ -1,0 +1,97 @@
+{
+  "command": [
+    "docker",
+    "run",
+    "--rm",
+    "--network=none",
+    "--volume",
+    "/home/rmz/git/rmatch-performance-measurements/work/mixed-regex-5000-8m:/data:ro",
+    "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "/data/patterns.tsv",
+    "/data/corpus.bin",
+    "9",
+    "3",
+    "4"
+  ],
+  "container_image_id": "sha256:166a9637b618531f551808f434814a37d922e524a4278fab23facf9aafa5067b",
+  "engine": {
+    "container_image": "rmatch-bench-rmatch:1.9.7-SNAPSHOT",
+    "name": "rmatch",
+    "threads": 4,
+    "variant": "parallel",
+    "version": "1.9.7-SNAPSHOT"
+  },
+  "exit_code": 0,
+  "host": {
+    "cpu_model": "AMD Ryzen 9 9950X3D 16-Core Processor",
+    "docker": "29.6.0",
+    "hostname": "agogo",
+    "logical_cpus": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43"
+  },
+  "inputs": {
+    "corpus.bin": {
+      "bytes": 8388608,
+      "sha256": "ce423a8fa2cc194238856f0b8b1dcdcce1610301b00ed9e77d16093ba0ecc15a"
+    },
+    "corpus.db": {
+      "bytes": 8404992,
+      "sha256": "3abf7eddc8b77964cc77a186fae22ad81b2c05e6b94e0ac98b43893172d6da18"
+    },
+    "patterns.hs": {
+      "bytes": 148893,
+      "sha256": "36603ec2b0a6535749294cbfeb4d2ad5701fa4f9f06d59c5723fa6298add3085"
+    },
+    "patterns.tsv": {
+      "bytes": 138893,
+      "sha256": "491b0c91a9fa3f23123dd007a4caa8ad13bc47708edf68e140892d104e3c6db5"
+    }
+  },
+  "metrics": {
+    "expression_count": 5000,
+    "matches_per_iteration": 5000,
+    "median_scan_ns": 132937021,
+    "mode": "4",
+    "prepare_ns": 67411556,
+    "scan_ns": [
+      232058290,
+      138506204,
+      126576465,
+      132937021,
+      124841621,
+      133718444,
+      127395230,
+      134602764,
+      129845151
+    ],
+    "throughput_mbit_per_second": 504.816969,
+    "warmup_ns": [
+      576510248,
+      323020639,
+      165393111
+    ]
+  },
+  "process_wall_seconds": 2.743301,
+  "repeats": 9,
+  "run_id": "3b0827a4-058c-4df3-a8aa-dce691a08a18",
+  "scenario": {
+    "corpus_size_bytes": 8388608,
+    "id": "mixed-regex-5000-8m",
+    "kind": "mixed_regex",
+    "matches_per_pattern": 1,
+    "pattern_count": 5000,
+    "schema_version": 1,
+    "seed": 20260710
+  },
+  "schema_version": 1,
+  "stderr": "",
+  "stdout": "{\"expression_count\":5000,\"prepare_ns\":67411556,\"warmup_ns\":[576510248, 323020639, 165393111],\"scan_ns\":[232058290, 138506204, 126576465, 132937021, 124841621, 133718444, 127395230, 134602764, 129845151],\"median_scan_ns\":132937021,\"throughput_mbit_per_second\":504.816969,\"matches_per_iteration\":5000,\"mode\":\"4\"}\n",
+  "timestamp_utc": "2026-07-12T21:01:51.399004+00:00",
+  "validation": {
+    "expected_matches_per_iteration": 5000,
+    "observed_matches_per_iteration": 5000,
+    "status": "pass"
+  },
+  "warmups": 3
+}

--- a/docs/regex-syntax-and-semantics.md
+++ b/docs/regex-syntax-and-semantics.md
@@ -1,0 +1,115 @@
+# Regex syntax and semantics
+
+This document defines the regular-expression language and match-reporting
+behavior proposed for rmatch 2.0. rmatch is not a drop-in replacement for
+`java.util.regex`, PCRE, or RE2. A pattern outside this documented surface is
+unsupported even if a particular build happens to accept it.
+
+## Supported syntax
+
+| Construct | Syntax | Meaning |
+|---|---|---|
+| Literal | `abc` | The exact character sequence |
+| Concatenation | `ab` | Match `a`, then `b` |
+| Alternation | `a\|b` | Match either branch |
+| Optional | `a?` | Zero or one `a` |
+| Repetition | `a*`, `a+` | Zero-or-more or one-or-more |
+| Counted repetition | `a{m}`, `a{m,n}`, `a{m,}` | Exact, bounded, or lower-bounded repetition |
+| Grouping | `(ab)`, `(?:ab)` | Grouping without capture semantics |
+| Any character | `.` | Any character, including newline |
+| Character class | `[abc]`, `[a-z]` | One listed character or range member |
+| Negated class | `[^abc]` | One character outside the class |
+| Shorthand class | `\d`, `\w`, `\s` | ASCII digit, word, or whitespace character |
+| Negated shorthand | `\D`, `\W`, `\S` | Complement of the corresponding shorthand |
+| Line anchors | `^`, `$` | Start or end of a line as defined below |
+| Word assertions | `\b`, `\B` | ASCII word boundary or non-boundary |
+| Prefix flag | `(?i)` | ASCII case-insensitive matching for the pattern |
+| DOTALL prefix | `(?s)` | Accepted; `.` already matches newline |
+
+`(?i)` and `(?s)` may be combined at the beginning, for example `(?is)a.b`.
+Flags are prefix-only. Applications may express case-insensitivity without
+rewriting pattern strings by passing `PatternFlag.CASE_INSENSITIVE` to
+`Matcher.add`.
+
+Counted repetition expands the compiled expression and is capped at 1,000.
+Invalid or excessive bounds fail during pattern registration.
+
+## Escapes and character rules
+
+The supported escaped literals include `\\`, `\.`, `\*`, `\+`, `\?`, `\[`,
+and `\(`. The control escapes `\n`, `\t`, `\r`, and `\f` are supported.
+Unknown escapes and a trailing backslash are errors.
+
+The shorthand and boundary definitions are intentionally ASCII-oriented:
+
+- `\d` is `[0-9]`.
+- `\w` is ASCII letters, digits, and underscore.
+- `\s` is space, tab, newline, vertical tab, form feed, or carriage return.
+- `\b` is a position where exactly one adjacent character is a `\w`
+  character; `\B` is its complement.
+
+Case-insensitive matching applies Java's single-`char` upper- and lower-case
+mapping at compile time. It does not promise locale-sensitive or multi-code-
+point Unicode folding, and 2.0 makes no Unicode property-class contract.
+
+## Anchors
+
+`^` and `$` are line anchors without requiring a separate multiline mode:
+
+- `^` succeeds at position zero and immediately after `\n`.
+- `$` succeeds at end of input and immediately before `\n`.
+
+Anchors are semantic assertions and may appear inside groups and alternations.
+Input-only anchors such as `\A`, `\z`, and `\Z` are not supported.
+
+## Match selection
+
+For each registered pattern and each input start position, rmatch reports the
+longest match beginning at that position. Matches beginning at different
+positions are all eligible, including overlapping and nested spans. For
+example, `a+` against `aaa` reports `[0,3)`, `[1,3)`, and `[2,3)`.
+
+Different registered patterns are independent. If both `a` and `ab` are
+registered, each may report its own match beginning at the same position.
+Registering distinct actions for one pattern keeps the actions distinct.
+
+Callbacks receive half-open `[start, end)` offsets, matching
+`String.substring(start, end)` and `Buffer.getString(start, end)`. Callback
+ordering is unspecified. Partitioned matchers may call actions concurrently.
+
+Pure zero-width patterns are not part of the 2.0 reporting contract. Assertions
+are supported when they constrain a match that consumes at least one
+character.
+
+## Deliberate exclusions
+
+The following are not supported in 2.0:
+
+- capture groups and captured-substring extraction
+- backreferences such as `\1`
+- lookahead and lookbehind
+- scoped or mid-pattern flags such as `a(?i)b`
+- lazy and possessive quantifiers
+- atomic groups
+- Unicode property classes
+- input-only anchors `\A`, `\z`, and `\Z`
+- pure zero-width match reporting
+- a non-DOTALL mode for `.`
+
+Backreferences are non-regular and conflict with rmatch's finite-automaton
+model. Other exclusions may be investigated later, but they are not implicit
+2.x compatibility promises.
+
+## Errors
+
+`Matcher.add` throws `RegexpParserException` when a pattern is malformed or
+uses unsupported syntax. The matcher remains available for registering a valid
+pattern after such a failure. Applications generating large pattern sets
+should report the rejected pattern together with the exception message.
+
+## Stability boundary
+
+For the 2.x line, semantic-versioning compatibility covers the exported
+`no.rmz.rmatch` API and the behavior documented here. Internal compiler,
+automaton, prefilter, diagnostic, and implementation packages are not extension
+contracts and may change between compatible releases.

--- a/docs/release-notes-2.0.0-RC1.md
+++ b/docs/release-notes-2.0.0-RC1.md
@@ -1,0 +1,89 @@
+# rmatch 2.0.0-RC1 release notes (draft)
+
+`2.0.0-RC1` is the first release intended for serious evaluation by potential
+users. rmatch is a Java library for applying many regular expressions to the
+same input through one matching pipeline. It is most relevant when pattern sets
+number in the hundreds or thousands and are reused over substantial buffers.
+
+## Why 2.0 now
+
+The `1.x` line began as an experiment. The implementation demonstrated that a
+shared automaton could offer useful many-pattern matching, but much of the
+early series delivered theoretical promise rather than a dependable library.
+The `1.9.x` releases were a sequence of engineering steps toward changing that:
+correctness defects were fixed, matching semantics were pinned by tests, the
+public API was reduced to a small facade, packaging was prepared for Maven
+Central, and performance was measured against realistic alternatives.
+
+The project has no known users who need a detailed `1.9.x` migration manual.
+Treat that series as release preparation rather than as a compatibility
+baseline. The purpose of 2.0 is to give potential users something they can try
+with a fair chance of finding it correct, understandable, and useful.
+
+## Runtime requirement
+
+rmatch 2.0 requires Java 21 or newer. Artifacts are compiled with
+`--release 21`; they cannot be loaded on older Java runtimes. Java 21 is both
+the language/toolchain baseline and the lower compatibility boundary for the
+2.x line. The project also verifies the build on a newer Java release in CI.
+
+## Public API
+
+The supported JPMS module is `no.rmz.rmatch`, exporting only the package of the
+same name. Its application-facing API consists of:
+
+- `RMatch`, the factory and input-adapter facade
+- `Matcher`, the build-then-use matcher lifecycle
+- `Action`, the match callback
+- `Buffer`, the positional input contract
+- `PatternFlag`, per-pattern options
+- `RegexpParserException`, malformed or unsupported pattern reporting
+
+Matchers are `AutoCloseable`. Register all patterns before the first scan,
+reuse the matcher for subsequent inputs, and close it when finished. Match
+callbacks receive half-open `[start, end)` offsets. A partitioned matcher may
+invoke callbacks concurrently and does not promise callback order.
+
+## Dependencies and packaging
+
+The published `no.rmz:rmatch` artifact has no third-party compile-time or
+runtime dependencies. Test and benchmark libraries remain project-local, and
+`rmatch-tester` is not part of the Maven Central release lane.
+
+## Syntax and matching behavior
+
+rmatch deliberately implements a regular-language subset rather than claiming
+drop-in Java or PCRE compatibility. The normative supported surface, matching
+rules, anchors, character classes, flags, and exclusions are documented in
+[Regex syntax and semantics](regex-syntax-and-semantics.md).
+
+Notable exclusions include captures, backreferences, lookaround, scoped flags,
+input-only anchors, and pure zero-width match reporting. Unsupported or
+malformed syntax fails during registration with `RegexpParserException`.
+
+## Performance evidence
+
+The current public campaign compares rmatch 1.9.6 with RE2/J, Java regex, and
+Hyperscan over 8 MiB and 50 MiB generated fixtures containing 1,000 through
+10,000 expressions. Every retained timing first passes exact match-count
+validation. The campaign shows where RE2/J leads and where rmatch's
+many-pattern design crosses over as pattern sets and inputs grow.
+
+The benchmark remains exploratory rather than a universal performance claim.
+Harness code, calibrated thread counts, engine versions, scenarios, and raw
+receipts are available in the
+[rmatch performance measurements project](https://github.com/la3lma/rmatch-performance-measurements).
+
+The final pre-RC regression gate compares the current candidate directly with
+published `1.9.6` over eight 8 MiB and 50 MiB cells. All match counts agree;
+the largest slowdown is 2.92% and the largest speedup is 9.58%. Raw receipts
+and the four-mode consumer verification are recorded in
+[the pre-RC evidence bundle](benchmark-receipts/2.0-pre-rc-2026-07-12/README.md).
+
+## RC purpose
+
+RC1 freezes the proposed 2.0 API and documented semantics for external review.
+Feedback should focus on correctness, API friction, documentation gaps,
+packaging, and workloads where the performance profile differs from the
+published evidence. A final `2.0.0` follows only after the release candidate has
+been exercised as a clean Maven, Gradle, class-path, and JPMS dependency.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # rmatch release process
 
-This document describes the cautious release lane for the pre-2.0 series.
+This document describes the cautious release lane for rmatch.
 The detailed living checklist is in
 [maven-central-release-checklist.md](maven-central-release-checklist.md).
 
@@ -11,6 +11,12 @@ The detailed living checklist is in
 - `1.99.x`: optional final pre-2.0 preview line if the syntax/API contract needs
   one last public shakeout.
 - `2.0.0`: stable, fully documented release line.
+
+The proposed first candidate is `2.0.0-RC1`. It requires Java 21 or newer;
+artifacts compiled with `--release 21` cannot run on an older JVM. The draft
+release note is [release-notes-2.0.0-RC1.md](release-notes-2.0.0-RC1.md), and
+the proposed stable language contract is
+[regex-syntax-and-semantics.md](regex-syntax-and-semantics.md).
 
 ## Public artifact lane
 
@@ -63,8 +69,7 @@ Check that `rmatch` does not leak test dependencies:
 mvn -q -pl rmatch dependency:tree -Dscope=compile
 ```
 
-Expected compile/runtime dependencies for `no.rmz:rmatch` are limited to
-Aho-Corasick.
+Expected compile/runtime dependencies for `no.rmz:rmatch` are empty.
 
 ## Maven Central upload
 

--- a/scripts/verify-consumers-docker.sh
+++ b/scripts/verify-consumers-docker.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERSION=$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$ROOT/pom.xml" | head -n 1)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/rmatch-consumers.XXXXXX")
+M2="$WORK/m2"
+MAVEN_IMAGE=${MAVEN_IMAGE:-maven:3.9-eclipse-temurin-21}
+GRADLE_IMAGE=${GRADLE_IMAGE:-gradle:8.14-jdk21}
+cleanup() {
+  docker run --rm -v "$WORK:/work" "$MAVEN_IMAGE" \
+    sh -c 'rm -rf /work/* /work/.[!.]* /work/..?*' >/dev/null 2>&1 || true
+  rmdir "$WORK" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$M2" "$WORK/src/example" "$WORK/maven/src/main/java/example"
+mkdir -p "$WORK/gradle/src/main/java/example" "$WORK/jpms/src/example.consumer/example"
+
+cat > "$WORK/src/example/Example.java" <<'JAVA'
+package example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import no.rmz.rmatch.RMatch;
+
+public final class Example {
+  public static void main(String[] args) throws Exception {
+    AtomicInteger matches = new AtomicInteger();
+    try (var matcher = RMatch.newMatcher(2)) {
+      matcher.add("WARN|ERROR", (buffer, start, end) -> matches.incrementAndGet());
+      matcher.match(RMatch.stringBuffer("INFO WARN ERROR"));
+    }
+    if (matches.get() != 2) {
+      throw new AssertionError("expected 2 matches, got " + matches.get());
+    }
+    System.out.println("consumer PASS: " + matches.get() + " matches");
+  }
+}
+JAVA
+
+cp "$WORK/src/example/Example.java" "$WORK/maven/src/main/java/example/Example.java"
+cp "$WORK/src/example/Example.java" "$WORK/gradle/src/main/java/example/Example.java"
+cp "$WORK/src/example/Example.java" "$WORK/jpms/src/example.consumer/example/Example.java"
+
+cat > "$WORK/maven/pom.xml" <<XML
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId><artifactId>consumer</artifactId><version>1</version>
+  <properties><maven.compiler.release>21</maven.compiler.release></properties>
+  <dependencies><dependency><groupId>no.rmz</groupId><artifactId>rmatch</artifactId><version>$VERSION</version></dependency></dependencies>
+</project>
+XML
+
+cat > "$WORK/gradle/settings.gradle.kts" <<'GRADLE'
+rootProject.name = "rmatch-consumer"
+GRADLE
+cat > "$WORK/gradle/build.gradle.kts" <<GRADLE
+plugins { application }
+repositories { maven { url = uri("$M2") }; mavenCentral() }
+dependencies { implementation("no.rmz:rmatch:$VERSION") }
+java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+application { mainClass = "example.Example" }
+GRADLE
+
+cat > "$WORK/jpms/src/example.consumer/module-info.java" <<'JAVA'
+module example.consumer {
+  requires no.rmz.rmatch;
+}
+JAVA
+
+docker run --rm -v "$ROOT:/src" -v "$M2:/m2" -w /src "$MAVEN_IMAGE" \
+  mvn -q -B -pl rmatch -am -Dmaven.repo.local=/m2 -DskipTests -Dspotbugs.skip=true install
+
+docker run --rm -v "$WORK/maven:/work" -v "$M2:/m2" -w /work "$MAVEN_IMAGE" \
+  mvn -q -B -Dmaven.repo.local=/m2 package
+docker run --rm -v "$WORK/maven:/work" -v "$M2:/m2" -w /work "$MAVEN_IMAGE" \
+  java -cp "target/classes:/m2/no/rmz/rmatch/$VERSION/rmatch-$VERSION.jar" example.Example
+
+docker run --rm -v "$WORK/gradle:/work" -v "$M2:$M2" -w /work "$GRADLE_IMAGE" \
+  gradle --no-daemon --console=plain run
+
+mkdir -p "$WORK/classpath-classes" "$WORK/jpms-mods"
+docker run --rm -v "$WORK:/work" -w /work "$MAVEN_IMAGE" sh -c \
+  "javac --release 21 -cp m2/no/rmz/rmatch/$VERSION/rmatch-$VERSION.jar -d classpath-classes src/example/Example.java && java -cp classpath-classes:m2/no/rmz/rmatch/$VERSION/rmatch-$VERSION.jar example.Example"
+
+docker run --rm -v "$WORK:/work" -w /work "$MAVEN_IMAGE" sh -c \
+  "javac --release 21 --module-path m2/no/rmz/rmatch/$VERSION/rmatch-$VERSION.jar -d jpms-mods --module-source-path jpms/src -m example.consumer && java --module-path jpms-mods:m2/no/rmz/rmatch/$VERSION/rmatch-$VERSION.jar -m example.consumer/example.Example"
+
+echo "All consumer modes PASS for no.rmz:rmatch:$VERSION"


### PR DESCRIPTION
## Summary
- draft user-facing 2.0.0-RC1 release notes and explain the experimental 1.x history
- publish a normative 2.0 syntax and matching-semantics reference
- state the Java 21 runtime and compatibility boundary
- add a repeatable Docker consumer gate for Maven, Gradle, classpath, and JPMS
- archive the final agogo regression receipts against published 1.9.6
- update the 2.0 checklist only where evidence now exists

## Verification
- full Maven reactor verify passes
- all four Docker consumer modes pass on the 16-core/32-thread AMD Ryzen 9 9950X3D host
- eight paired regression scenarios pass exact match validation
- candidate range versus 1.9.6: -2.92% to +9.58%, within the 3% slowdown gate
- all local Markdown links and 16 archived JSON receipts validated
