### PR TITLE
Release rmatch 2.0.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 1.9.7-SNAPSHOT - in development
+## 2.0.0-RC1 - 2026-07-13
 
-- Continue pre-2.0 stabilization after publishing `1.9.6`.
-- Drafted the `2.0.0-RC1` release notes and a normative syntax-and-semantics
+- Cut the first public 2.0 release candidate after publishing `1.9.6`.
+- Added the `2.0.0-RC1` release notes and a normative syntax-and-semantics
   reference, including the Java 21 baseline, supported language, deliberate
   exclusions, longest-per-start matching, overlapping matches, and callback
   behavior.
@@ -15,6 +15,11 @@
   the observed range was 2.92% slower to 9.58% faster, within the agreed 3%
   regression limit. Raw receipts are under
   `docs/benchmark-receipts/2.0-pre-rc-2026-07-12/`.
+- Added a reviewed public-API signature baseline and an automated compatibility
+  check for changes between release candidates.
+- Refreshed stable test/build tooling to JUnit 6.1.2, SpotBugs Maven Plugin
+  4.10.3.0, and JaCoCo 0.8.15; milestone and beta plugin updates remain excluded
+  from the release lane.
 
 ## 1.9.6 - pre-2.0 Maven Central release candidate
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GATE_SKIP_REBUILD ?= 0
 .PHONY: help main main-local main-docker build test clean profile fmt spotless spotbugs javadocs release-central-javadoc-check
 .PHONY: perf-local-setup perf-local-smoke perf-local-baseline perf-local-candidate perf-docker-smoke
 .PHONY: gate-baseline gate-candidate
-.PHONY: release-central-preflight release-central-profile-check release-central-publish release-consumer-smoke
+.PHONY: release-central-preflight release-central-profile-check release-central-publish release-consumer-smoke api-compat-check release-artifact-check
 
 help: ## [core] Show available top-level targets
 	@echo "Top-level rmatch Make targets"
@@ -116,6 +116,12 @@ release-central-profile-check: ## [core] Verify Central release profile wiring w
 
 release-consumer-smoke: ## [core] Test Maven, Gradle, classpath, and JPMS consumers in Docker
 	bash scripts/verify-consumers-docker.sh
+
+api-compat-check: ## [core] Verify the exported public API matches the reviewed RC baseline
+	bash scripts/verify-public-api.sh
+
+release-artifact-check: ## [core] Inspect unsigned Central-profile artifacts and metadata
+	bash scripts/verify-release-artifacts.sh
 
 release-central-publish: ## [core] Publish parent+rmatch to Maven Central (requires token+GPG setup and non-SNAPSHOT version)
 	$(MVN) -B -pl rmatch -am -Pcentral-release -DskipTests -Dspotbugs.skip=true -Dgpg.skip=false deploy

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The branch-vs-`main` protocol lives in
 
 ## Use from Maven Central
 
-The examples below use the public API published with `1.9.6`.
+The examples below use the public API in `2.0.0-RC1`.
 
 Add rmatch to an existing Maven project:
 
@@ -83,7 +83,7 @@ Add rmatch to an existing Maven project:
 <dependency>
   <groupId>no.rmz</groupId>
   <artifactId>rmatch</artifactId>
-  <version>1.9.6</version>
+  <version>2.0.0-RC1</version>
 </dependency>
 ```
 
@@ -95,7 +95,7 @@ For Gradle:
 
 ```kotlin
 dependencies {
-    implementation("no.rmz:rmatch:1.9.6")
+    implementation("no.rmz:rmatch:2.0.0-RC1")
 }
 ```
 
@@ -129,7 +129,7 @@ For a complete scratch project, use this full `pom.xml`:
     <dependency>
       <groupId>no.rmz</groupId>
       <artifactId>rmatch</artifactId>
-      <version>1.9.6</version>
+      <version>2.0.0-RC1</version>
     </dependency>
   </dependencies>
 </project>
@@ -318,8 +318,8 @@ and overlap behavior, is in
 ## Release Notes and Roadmap
 
 - [CHANGELOG.md](CHANGELOG.md) describes the `1.9.x` pre-release line.
-- [docs/release-notes-2.0.0-RC1.md](docs/release-notes-2.0.0-RC1.md) is the
-  draft user-facing release note for the first 2.0 candidate.
+- [docs/release-notes-2.0.0-RC1.md](docs/release-notes-2.0.0-RC1.md) contains
+  the user-facing release notes for the first 2.0 candidate.
 - [docs/regex-syntax-and-semantics.md](docs/regex-syntax-and-semantics.md)
   defines the proposed stable syntax and matching behavior.
 - [docs/release.md](docs/release.md) documents the Maven Central release lane.

--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -179,14 +179,23 @@
 <p>This is the broad pre-2.0 checklist. It is intentionally
 over-inclusive: assume items here should be completed unless they are
 explicitly removed before the 2.0 release lane starts.</p>
+<h2 id="rc1-gate-status">RC1 Gate Status</h2>
+<p>The RC1 gate is distinct from the broader final-2.0 backlog below. As
+of 2026-07-13, all pre-upload RC1 gates are complete: API and syntax
+contracts, Java 21 packaging, full tests, the agogo performance
+regression gate, four-mode consumer tests, dependency hygiene, release
+notes, generated Javadocs, and the reviewed API-signature baseline.
+Central upload and the checks that inherently require a published
+candidate remain open.</p>
 <h2 id="release-goal">Release Goal</h2>
 <ul class="task-list">
 <li><label><input type="checkbox" checked="" />State the 2.0 promise in
 one paragraph: what rmatch is for, what it is not for, and what
 compatibility promises start at 2.0.</label></li>
-<li><label><input type="checkbox" />Decide whether the last preview
-before 2.0 is <code>1.9.x</code>, <code>1.99.x</code>, or direct
-<code>2.0.0</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Decide whether the last
+preview before 2.0 is <code>1.9.x</code>, <code>1.99.x</code>, or direct
+<code>2.0.0</code>: proceed with <code>2.0.0-RC1</code> after
+<code>1.9.6</code>.</label></li>
 <li><label><input type="checkbox" checked="" />Decide whether to cut
 <code>2.0.0-RC1</code> instead of using a <code>1.99.x</code> preview
 line.</label></li>
@@ -198,30 +207,31 @@ compatibility promise explicitly: semantic versioning covers the
 exported root API plus documented matching behavior and syntax;
 unexported implementation packages are not compatibility
 contracts.</label></li>
-<li><label><input type="checkbox" />State the deprecation and removal
-policy for the 2.x line, including how much notice users receive before
-a public API is removed.</label></li>
+<li><label><input type="checkbox" checked="" />State the deprecation and
+removal policy for the 2.x line, including how much notice users receive
+before a public API is removed.</label></li>
 <li><label><input type="checkbox" />Publish at least one 2.0 release
 candidate and leave a short, deliberate feedback window for external
 users before the final release.</label></li>
-<li><label><input type="checkbox" />Confirm that
+<li><label><input type="checkbox" checked="" />Confirm that
 <code>rmatch-tester</code> remains unpublished and
 project-local.</label></li>
-<li><label><input type="checkbox" />Confirm that the public Maven
-Central artifacts remain only <code>no.rmz:rmatch-parent</code> and
-<code>no.rmz:rmatch</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm that the public
+Maven Central artifacts remain only <code>no.rmz:rmatch-parent</code>
+and <code>no.rmz:rmatch</code>.</label></li>
 </ul>
 <h2 id="public-api-surface">Public API Surface</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Verify that ordinary users can do
-the important work using only the root <code>no.rmz.rmatch</code>
-package.</label></li>
-<li><label><input type="checkbox" />Verify that the published JPMS
-module exports only intentional public API.</label></li>
-<li><label><input type="checkbox" />Verify that Javadocs expose only
-intentional public API, not compiler, engine, implementation, utility,
-node-management, test, or diagnostic packages.</label></li>
-<li><label><input type="checkbox" />Inspect the generated
+<li><label><input type="checkbox" checked="" />Verify that ordinary
+users can do the important work using only the root
+<code>no.rmz.rmatch</code> package.</label></li>
+<li><label><input type="checkbox" checked="" />Verify that the published
+JPMS module exports only intentional public API.</label></li>
+<li><label><input type="checkbox" checked="" />Verify that Javadocs
+expose only intentional public API, not compiler, engine,
+implementation, utility, node-management, test, or diagnostic
+packages.</label></li>
+<li><label><input type="checkbox" checked="" />Inspect the generated
 <code>-javadoc.jar</code>, not just local generated HTML.</label></li>
 <li><label><input type="checkbox" />Inspect javadoc.io after publication
 and confirm it shows the intended surface.</label></li>
@@ -238,40 +248,42 @@ constructors and factories for internal types.</label></li>
 <li><label><input type="checkbox" />Remove public interfaces that are
 only internal wiring unless they are truly extension
 contracts.</label></li>
-<li><label><input type="checkbox" />Review whether <code>Buffer</code>,
-<code>Matcher</code>, <code>Action</code>, <code>RMatch</code>, and
-<code>RegexpParserException</code> are the complete intended public
-facade.</label></li>
+<li><label><input type="checkbox" checked="" />Review whether
+<code>Buffer</code>, <code>Matcher</code>, <code>Action</code>,
+<code>RMatch</code>, and <code>RegexpParserException</code> are the
+complete intended public facade.</label></li>
 <li><label><input type="checkbox" />Ensure public names are clear enough
 that examples do not need to explain surprising behavior.</label></li>
-<li><label><input type="checkbox" />Decide whether match callback
-offsets should become half-open <code>[start, end)</code> in 2.0,
-matching <code>String.substring</code>, <code>MatchResult</code>, and
-common Java convention.</label></li>
+<li><label><input type="checkbox" checked="" />Decide whether match
+callback offsets should become half-open <code>[start, end)</code> in
+2.0, matching <code>String.substring</code>, <code>MatchResult</code>,
+and common Java convention.</label></li>
 <li><label><input type="checkbox" />If callback offsets remain
 inclusive, add a public helper so user code does not repeatedly write
 <code>buffer.getString(start, end + 1)</code>.</label></li>
-<li><label><input type="checkbox" />Decide whether <code>Matcher</code>
-should extend <code>AutoCloseable</code>.</label></li>
-<li><label><input type="checkbox" />If <code>Matcher</code> extends
-<code>AutoCloseable</code>, update README examples to use
+<li><label><input type="checkbox" checked="" />Decide whether
+<code>Matcher</code> should extend
+<code>AutoCloseable</code>.</label></li>
+<li><label><input type="checkbox" checked="" />If <code>Matcher</code>
+extends <code>AutoCloseable</code>, update README examples to use
 try-with-resources.</label></li>
-<li><label><input type="checkbox" />Decide whether
+<li><label><input type="checkbox" checked="" />Decide whether
 <code>shutdown()</code> remains part of the public lifecycle API, is
 renamed, or is complemented by <code>close()</code>.</label></li>
 <li><label><input type="checkbox" />Decide whether matcher worker
 threads should be daemon threads as a safety net.</label></li>
-<li><label><input type="checkbox" />Reserve a future-compatible API
-shape for flags, such as <code>add(pattern, flags, action)</code>, even
-if not all flags ship in 2.0.</label></li>
-<li><label><input type="checkbox" />Decide the public representation for
-flags before 2.0 freezes: enum set, integer bit flags, or another
-explicit type.</label></li>
-<li><label><input type="checkbox" />Document what happens when an
-<code>Action</code> throws during matching.</label></li>
-<li><label><input type="checkbox" />Document whether one throwing action
-aborts the scan immediately or after already-started partitions
-finish.</label></li>
+<li><label><input type="checkbox" checked="" />Reserve a
+future-compatible API shape for flags, such as
+<code>add(pattern, flags, action)</code>, even if not all flags ship in
+2.0.</label></li>
+<li><label><input type="checkbox" checked="" />Decide the public
+representation for flags before 2.0 freezes: enum set, integer bit
+flags, or another explicit type.</label></li>
+<li><label><input type="checkbox" checked="" />Document what happens
+when an <code>Action</code> throws during matching.</label></li>
+<li><label><input type="checkbox" checked="" />Document whether one
+throwing action aborts the scan immediately or after already-started
+partitions finish.</label></li>
 <li><label><input type="checkbox" checked="" />Adopt and document a
 build-then-use matcher lifecycle: the first <code>match()</code> freezes
 registration and later <code>add()</code> calls fail.</label></li>
@@ -305,33 +317,35 @@ regardless of <code>equals()</code>.</label></li>
 <li><label><input type="checkbox" checked="" />Specify that callback
 ordering is not guaranteed, including with a single-engine
 matcher.</label></li>
-<li><label><input type="checkbox" />Freeze and document remaining result
-semantics: longest-per-start behavior, overlapping matches, callback
-multiplicity across patterns, and duplicate pattern text with different
-flags.</label></li>
+<li><label><input type="checkbox" checked="" />Freeze and document
+remaining result semantics: longest-per-start behavior, overlapping
+matches, callback multiplicity across patterns, and duplicate pattern
+text with different flags.</label></li>
 <li><label><input type="checkbox" />Ensure parser failures identify the
 unsupported or malformed construct and its location well enough for a
 user to repair a large generated pattern.</label></li>
 </ul>
 <h2 id="buffer-and-input-contract">Buffer and Input Contract</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Keep the public materializing
-helpers named <code>RMatch.stringBuffer(...)</code>, so callers see that
-the whole input is read into a <code>String</code>.</label></li>
-<li><label><input type="checkbox" />Provide convenience overloads for
-<code>String</code>, <code>CharSequence</code>, <code>Path</code> with
-<code>Charset</code>, <code>Reader</code>, and <code>InputStream</code>
-with <code>Charset</code>, if retained after API review.</label></li>
-<li><label><input type="checkbox" />Document that <code>Reader</code>
-and <code>InputStream</code> helpers consume but do not close the
-supplied object.</label></li>
-<li><label><input type="checkbox" />Document that current public helpers
-are not streaming, windowed, mmap, or lazy file-backed
+<li><label><input type="checkbox" checked="" />Keep the public
+materializing helpers named <code>RMatch.stringBuffer(...)</code>, so
+callers see that the whole input is read into a
+<code>String</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Provide convenience
+overloads for <code>String</code>, <code>CharSequence</code>,
+<code>Path</code> with <code>Charset</code>, <code>Reader</code>, and
+<code>InputStream</code> with <code>Charset</code>, if retained after
+API review.</label></li>
+<li><label><input type="checkbox" checked="" />Document that
+<code>Reader</code> and <code>InputStream</code> helpers consume but do
+not close the supplied object.</label></li>
+<li><label><input type="checkbox" checked="" />Document that current
+public helpers are not streaming, windowed, mmap, or lazy file-backed
 implementations.</label></li>
 <li><label><input type="checkbox" />Document why the current
 <code>Buffer</code> contract requires finite, replayable input with
 substring lookup by offsets and independent cloned cursors.</label></li>
-<li><label><input type="checkbox" />Document that custom
+<li><label><input type="checkbox" checked="" />Document that custom
 <code>Buffer</code> implementations can be passed directly to
 <code>Matcher.match(Buffer)</code>.</label></li>
 <li><label><input type="checkbox" />State the contract a custom
@@ -344,11 +358,11 @@ docs.</label></li>
 <li><label><input type="checkbox" />Record that arbitrary streaming
 would need a separate bounded-window or maximum-lookback design and is
 not part of 2.0 unless intentionally added.</label></li>
-<li><label><input type="checkbox" />Add tests for every retained public
-<code>stringBuffer(...)</code> overload.</label></li>
-<li><label><input type="checkbox" />Add at least one small example or
-test showing that a user-supplied <code>Buffer</code> can be matched
-directly.</label></li>
+<li><label><input type="checkbox" checked="" />Add tests for every
+retained public <code>stringBuffer(...)</code> overload.</label></li>
+<li><label><input type="checkbox" checked="" />Add at least one small
+example or test showing that a user-supplied <code>Buffer</code> can be
+matched directly.</label></li>
 <li><label><input type="checkbox" />Decide whether <code>Buffer</code>
 should stop extending
 <code>Comparable&lt;Buffer&gt;</code>.</label></li>
@@ -379,10 +393,11 @@ type.</label></li>
 </ul>
 <h2 id="deprecated-and-unused-api">Deprecated and Unused API</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Search for all deprecated classes,
-methods, constructors, and fields.</label></li>
-<li><label><input type="checkbox" />Remove deprecated API that is unused
-or can be made unused by sensible internal changes.</label></li>
+<li><label><input type="checkbox" checked="" />Search for all deprecated
+classes, methods, constructors, and fields.</label></li>
+<li><label><input type="checkbox" checked="" />Remove deprecated API
+that is unused or can be made unused by sensible internal
+changes.</label></li>
 <li><label><input type="checkbox" />If a deprecated API is still needed,
 remove the deprecation and document why it remains part of the public or
 internal contract.</label></li>
@@ -397,8 +412,8 @@ sweep.</label></li>
 </ul>
 <h2 id="graph-and-diagnostic-code">Graph and Diagnostic Code</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Review graph-printing support,
-including <code>getEdgesToPrint</code> and related classes or
+<li><label><input type="checkbox" checked="" />Review graph-printing
+support, including <code>getEdgesToPrint</code> and related classes or
 methods.</label></li>
 <li><label><input type="checkbox" />Decide whether graph-printing
 belongs in core at all.</label></li>
@@ -407,8 +422,8 @@ it behind a clearly internal or diagnostic boundary.</label></li>
 <li><label><input type="checkbox" />If graph-printing can be
 reconstructed by inspecting core structures, remove dedicated
 graph-printing API from production surfaces.</label></li>
-<li><label><input type="checkbox" />Ensure graph-printing code does not
-leak into public Javadocs.</label></li>
+<li><label><input type="checkbox" checked="" />Ensure graph-printing
+code does not leak into public Javadocs.</label></li>
 </ul>
 <h2 id="regex-syntax-contract">Regex Syntax Contract</h2>
 <ul class="task-list">
@@ -423,12 +438,12 @@ documentation.</label></li>
 <li><label><input type="checkbox" checked="" />Verify word boundaries
 <code>\b</code> and <code>\B</code> behavior with tests and
 documentation.</label></li>
-<li><label><input type="checkbox" />Decide whether input anchors
-<code>\A</code>, <code>\z</code>, or <code>\Z</code> are in or out for
-2.0.</label></li>
-<li><label><input type="checkbox" />Decide whether pure zero-width match
-reporting is in or out for 2.0.</label></li>
-<li><label><input type="checkbox" />Decide whether
+<li><label><input type="checkbox" checked="" />Decide whether input
+anchors <code>\A</code>, <code>\z</code>, or <code>\Z</code> are in or
+out for 2.0.</label></li>
+<li><label><input type="checkbox" checked="" />Decide whether pure
+zero-width match reporting is in or out for 2.0.</label></li>
+<li><label><input type="checkbox" checked="" />Decide whether
 <code>MULTILINE</code>, non-DOTALL <code>.</code>, scoped flags, or
 other mode machinery is in or out for 2.0.</label></li>
 <li><label><input type="checkbox" />Ensure unsupported syntax fails
@@ -438,12 +453,12 @@ aligned with the tested behavior.</label></li>
 </ul>
 <h2 id="correctness-test-gate">Correctness Test Gate</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Run the full <code>rmatch</code>
-unit and semantics test suite.</label></li>
-<li><label><input type="checkbox" />Run the full
+<li><label><input type="checkbox" checked="" />Run the full
+<code>rmatch</code> unit and semantics test suite.</label></li>
+<li><label><input type="checkbox" checked="" />Run the full
 <code>rmatch-tester</code> suite.</label></li>
-<li><label><input type="checkbox" />Run differential tests against
-<code>java.util.regex</code> for the supported syntax
+<li><label><input type="checkbox" checked="" />Run differential tests
+against <code>java.util.regex</code> for the supported syntax
 subset.</label></li>
 <li><label><input type="checkbox" />Expand seeded differential testing
 to cover multiple seeds, anchors, word boundaries, escapes, counted
@@ -452,11 +467,11 @@ registered patterns.</label></li>
 <li><label><input type="checkbox" />Exercise hostile but valid patterns
 and inputs to establish practical bounds for compilation time, state
 growth, memory use, and scan completion.</label></li>
-<li><label><input type="checkbox" />Verify match counts before treating
-benchmark timings as evidence.</label></li>
-<li><label><input type="checkbox" />Verify edge cases for overlapping
-matches, longest-match behavior, anchors, word boundaries, negated
-classes, counted quantifiers, and case-insensitive
+<li><label><input type="checkbox" checked="" />Verify match counts
+before treating benchmark timings as evidence.</label></li>
+<li><label><input type="checkbox" checked="" />Verify edge cases for
+overlapping matches, longest-match behavior, anchors, word boundaries,
+negated classes, counted quantifiers, and case-insensitive
 matching.</label></li>
 <li><label><input type="checkbox" />Confirm all skipped tests are either
 intentionally skipped or removed.</label></li>
@@ -465,23 +480,23 @@ fixed during the 1.9.x line.</label></li>
 </ul>
 <h2 id="ci-gate">CI Gate</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Add or verify a GitHub Actions
-workflow that runs the full Maven test suite on pull
+<li><label><input type="checkbox" checked="" />Add or verify a GitHub
+Actions workflow that runs the full Maven test suite on pull
 requests.</label></li>
 <li><label><input type="checkbox" />Review Codacy critical/high findings
 manually; fix real command/path, reflection, dead-code, and
 release-hygiene issues, and explicitly reject style-only false
 positives.</label></li>
-<li><label><input type="checkbox" />Ensure CI runs more than smoke tests
-before 2.0.</label></li>
-<li><label><input type="checkbox" />Review <code>main-gate.yml</code> or
-its successor and ensure it does not merely compile plus run a tiny
-smoke subset.</label></li>
-<li><label><input type="checkbox" />Run CI on the documented Java
-baseline, expected to be Java 21 unless changed
+<li><label><input type="checkbox" checked="" />Ensure CI runs more than
+smoke tests before 2.0.</label></li>
+<li><label><input type="checkbox" checked="" />Review
+<code>main-gate.yml</code> or its successor and ensure it does not
+merely compile plus run a tiny smoke subset.</label></li>
+<li><label><input type="checkbox" checked="" />Run CI on the documented
+Java baseline, expected to be Java 21 unless changed
 deliberately.</label></li>
-<li><label><input type="checkbox" />Run CI on a current newer Java
-version as well, such as Java 25 or 26.</label></li>
+<li><label><input type="checkbox" checked="" />Run CI on a current newer
+Java version as well, such as Java 25 or 26.</label></li>
 <li><label><input type="checkbox" checked="" />Test the packaged
 candidate from clean external Maven and Gradle consumer projects, both
 on the class path and as a named JPMS module; do not rely only on
@@ -495,10 +510,12 @@ deliberately accepted.</label></li>
 <li><label><input type="checkbox" />Specifically fix, replace, or delete
 any stale Codacy workflow if it is still configured for
 <code>master</code> instead of <code>main</code>.</label></li>
-<li><label><input type="checkbox" />Add an API-compatibility gate such
-as japicmp or revapi after the 2.0 API is frozen.</label></li>
-<li><label><input type="checkbox" />Configure the API-compatibility gate
-so accidental 2.0.x breaking changes fail before release.</label></li>
+<li><label><input type="checkbox" checked="" />Add an API-compatibility
+gate after the proposed 2.0 API is frozen. The repository uses reviewed
+<code>javap</code> signatures for the exported facade.</label></li>
+<li><label><input type="checkbox" checked="" />Configure the
+API-compatibility gate so accidental 2.0.x breaking changes fail before
+release.</label></li>
 </ul>
 <h2 id="performance-gate">Performance Gate</h2>
 <ul class="task-list">
@@ -507,20 +524,20 @@ performance regression gate on the agreed high-core benchmark
 host.</label></li>
 <li><label><input type="checkbox" checked="" />Compare the 2.0 candidate
 against the latest published pre-2.0 release.</label></li>
-<li><label><input type="checkbox" />Compare rmatch against naive
-<code>java.util.regex</code> looping and RE2J looping using
+<li><label><input type="checkbox" checked="" />Compare rmatch against
+naive <code>java.util.regex</code> looping and RE2J looping using
 byte-identical corpora and pattern sets.</label></li>
-<li><label><input type="checkbox" />Publish a small benchmark matrix
-rather than one favorable workload: include literal-heavy,
+<li><label><input type="checkbox" checked="" />Publish a small benchmark
+matrix rather than one favorable workload: include literal-heavy,
 structured-regex, shared-prefix, and realistic mixed pattern sets over
 more than one corpus and scale.</label></li>
 <li><label><input type="checkbox" />Report registration/compilation
 cost, steady-state scan time, peak memory, and single-versus-default
 parallel execution where each is material.</label></li>
-<li><label><input type="checkbox" />Show representative cells where Java
-regex or RE2J wins as well as where rmatch wins, so the performance
-claim states a useful crossover rather than implying universal
-superiority.</label></li>
+<li><label><input type="checkbox" checked="" />Show representative cells
+where Java regex or RE2J wins as well as where rmatch wins, so the
+performance claim states a useful crossover rather than implying
+universal superiority.</label></li>
 <li><label><input type="checkbox" checked="" />Benchmark the packaged
 release-candidate JAR through the public API, not only reactor classes
 or internal benchmark hooks.</label></li>
@@ -535,14 +552,15 @@ release.</label></li>
 <li><label><input type="checkbox" checked="" />Capture raw benchmark
 receipts, summaries, and charts in
 <code>docs/benchmark-receipts/...</code>.</label></li>
-<li><label><input type="checkbox" />Update the README performance chart
-from a recent run of the current implementation.</label></li>
-<li><label><input type="checkbox" />Make the chart label hardware by
-class, CPU model, and core/thread count, not by private machine
-nickname.</label></li>
-<li><label><input type="checkbox" />Keep the developer performance
-regression protocol as a separate linked document, not a giant README
-section.</label></li>
+<li><label><input type="checkbox" checked="" />Update the README
+performance chart from a recent run of the current
+implementation.</label></li>
+<li><label><input type="checkbox" checked="" />Make the chart label
+hardware by class, CPU model, and core/thread count, not by private
+machine nickname.</label></li>
+<li><label><input type="checkbox" checked="" />Keep the developer
+performance regression protocol as a separate linked document, not a
+giant README section.</label></li>
 <li><label><input type="checkbox" checked="" />Investigate any material
 performance regression before release.</label></li>
 <li><label><input type="checkbox" checked="" />Record any material
@@ -550,69 +568,73 @@ performance improvement in release notes, with receipts.</label></li>
 </ul>
 <h2 id="dependency-hygiene">Dependency Hygiene</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Run a dependency freshness pass
-before the 2.0 release candidate.</label></li>
-<li><label><input type="checkbox" />Prefer current stable versions of
-dependencies and plugins where tests and compatibility
+<li><label><input type="checkbox" checked="" />Run a dependency
+freshness pass before the 2.0 release candidate.</label></li>
+<li><label><input type="checkbox" checked="" />Prefer current stable
+versions of dependencies and plugins where tests and compatibility
 allow.</label></li>
-<li><label><input type="checkbox" />Avoid beta, milestone, or abandoned
-dependencies unless explicitly justified.</label></li>
-<li><label><input type="checkbox" />Confirm <code>no.rmz:rmatch</code>
-has no unintended compile/runtime dependencies.</label></li>
-<li><label><input type="checkbox" />Confirm test-only dependencies do
-not leak into compile/runtime scopes.</label></li>
-<li><label><input type="checkbox" />Confirm the external Aho-Corasick
-dependency remains removed unless a new deliberate decision reintroduces
-it.</label></li>
-<li><label><input type="checkbox" />Run dependency tree checks for
-compile, runtime, and test scopes.</label></li>
-<li><label><input type="checkbox" />Run vulnerability or risk-oriented
-dependency checks if available in the local toolchain.</label></li>
-<li><label><input type="checkbox" />Record any accepted dependency risk
-in the release notes or release checklist.</label></li>
+<li><label><input type="checkbox" checked="" />Avoid beta, milestone, or
+abandoned dependencies unless explicitly justified.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm
+<code>no.rmz:rmatch</code> has no unintended compile/runtime
+dependencies.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm test-only
+dependencies do not leak into compile/runtime scopes.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm the external
+Aho-Corasick dependency remains removed unless a new deliberate decision
+reintroduces it.</label></li>
+<li><label><input type="checkbox" checked="" />Run dependency tree
+checks for compile, runtime, and test scopes.</label></li>
+<li><label><input type="checkbox" checked="" />Run vulnerability or
+risk-oriented dependency checks if available in the local
+toolchain.</label></li>
+<li><label><input type="checkbox" checked="" />Record any accepted
+dependency risk in the release notes or release checklist.</label></li>
 </ul>
 <h2 id="jpms-and-packaging">JPMS and Packaging</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Verify <code>module-info.java</code>
-names the module <code>no.rmz.rmatch</code>.</label></li>
-<li><label><input type="checkbox" />Verify
+<li><label><input type="checkbox" checked="" />Verify
+<code>module-info.java</code> names the module
+<code>no.rmz.rmatch</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Verify
 <code>jar --describe-module</code> reports the intended module
 metadata.</label></li>
-<li><label><input type="checkbox" />Verify no automatic-module warnings
-remain in the Central release profile.</label></li>
-<li><label><input type="checkbox" />Verify the main JAR does not contain
-stale classes from previous builds.</label></li>
-<li><label><input type="checkbox" />Run release verification from a
-clean checkout or after <code>clean</code>.</label></li>
-<li><label><input type="checkbox" />Inspect the JAR
+<li><label><input type="checkbox" checked="" />Verify no
+automatic-module warnings remain in the Central release
+profile.</label></li>
+<li><label><input type="checkbox" checked="" />Verify the main JAR does
+not contain stale classes from previous builds.</label></li>
+<li><label><input type="checkbox" checked="" />Run release verification
+from a clean checkout or after <code>clean</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Inspect the JAR
 manifest.</label></li>
-<li><label><input type="checkbox" />Inspect embedded Maven POM
-properties.</label></li>
-<li><label><input type="checkbox" />Verify classfile major version
-matches the documented Java baseline.</label></li>
+<li><label><input type="checkbox" checked="" />Inspect embedded Maven
+POM properties.</label></li>
+<li><label><input type="checkbox" checked="" />Verify classfile major
+version matches the documented Java baseline.</label></li>
 <li><label><input type="checkbox" />Make release artifacts reproducible
 where practical, including a fixed Maven build output timestamp, and
 compare clean-build hashes before release.</label></li>
-<li><label><input type="checkbox" />Verify source and Javadoc JARs are
-attached.</label></li>
-<li><label><input type="checkbox" />Verify generated <code>.asc</code>
-signatures for all published artifacts.</label></li>
+<li><label><input type="checkbox" checked="" />Verify source and Javadoc
+JARs are attached.</label></li>
+<li><label><input type="checkbox" checked="" />Verify generated
+<code>.asc</code> signatures for all candidate artifacts.</label></li>
 </ul>
 <h2 id="shipped-jar-hygiene">Shipped Jar Hygiene</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Remove direct
+<li><label><input type="checkbox" checked="" />Remove direct
 <code>System.out.println</code> usage from library code.</label></li>
-<li><label><input type="checkbox" />Route retained diagnostic output
-through <code>java.util.logging</code> or another deliberate logging
-boundary.</label></li>
-<li><label><input type="checkbox" />Review whether
+<li><label><input type="checkbox" checked="" />Route retained diagnostic
+output through <code>java.util.logging</code> or another deliberate
+logging boundary.</label></li>
+<li><label><input type="checkbox" checked="" />Review whether
 <code>BloomFilterMatchEngine</code> is live production code or a
 leftover experiment.</label></li>
-<li><label><input type="checkbox" />Remove dead experimental engines
-from the published artifact, or move them behind an internal/diagnostic
-boundary.</label></li>
-<li><label><input type="checkbox" />Turn Javadoc doclint back on for the
-public facade if feasible before 2.0.</label></li>
+<li><label><input type="checkbox" checked="" />Remove dead experimental
+engines from the published artifact, or move them behind an
+internal/diagnostic boundary.</label></li>
+<li><label><input type="checkbox" checked="" />Turn Javadoc doclint back
+on for the public facade if feasible before 2.0.</label></li>
 <li><label><input type="checkbox" />If doclint remains disabled,
 document the reason and a follow-up path.</label></li>
 <li><label><input type="checkbox" />Extract duplicated matcher
@@ -627,54 +649,55 @@ robustly or document any timeout and failure semantics.</label></li>
 </ul>
 <h2 id="documentation">Documentation</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Make README usable by an experienced
-Java developer in under five minutes.</label></li>
-<li><label><input type="checkbox" />Put the dependency snippet and
-smallest runnable example before the long benchmark discussion so a
-curious developer can try rmatch immediately.</label></li>
-<li><label><input type="checkbox" />Include Maven Central dependency
+<li><label><input type="checkbox" checked="" />Make README usable by an
+experienced Java developer in under five minutes.</label></li>
+<li><label><input type="checkbox" checked="" />Put the dependency
+snippet and smallest runnable example before the long benchmark
+discussion so a curious developer can try rmatch
+immediately.</label></li>
+<li><label><input type="checkbox" checked="" />Include Maven Central
+dependency instructions near the top of README.</label></li>
+<li><label><input type="checkbox" checked="" />Include Gradle dependency
 instructions near the top of README.</label></li>
-<li><label><input type="checkbox" />Include Gradle dependency
-instructions near the top of README.</label></li>
-<li><label><input type="checkbox" />Keep the README copy-paste example
-minimal, correct, and tested against a clean consumer
+<li><label><input type="checkbox" checked="" />Keep the README
+copy-paste example minimal, correct, and tested against a clean consumer
 project.</label></li>
-<li><label><input type="checkbox" />Explain when to use rmatch and when
-not to use it.</label></li>
-<li><label><input type="checkbox" />Explain how rmatch performance
-comparisons are made.</label></li>
-<li><label><input type="checkbox" />Link from README to the performance
-regression protocol.</label></li>
-<li><label><input type="checkbox" />Remove stale references to
-historical experiments that do not represent the current
+<li><label><input type="checkbox" checked="" />Explain when to use
+rmatch and when not to use it.</label></li>
+<li><label><input type="checkbox" checked="" />Explain how rmatch
+performance comparisons are made.</label></li>
+<li><label><input type="checkbox" checked="" />Link from README to the
+performance regression protocol.</label></li>
+<li><label><input type="checkbox" checked="" />Remove stale references
+to historical experiments that do not represent the current
 implementation.</label></li>
-<li><label><input type="checkbox" />Remove internal-only bug IDs or
-notes that are meaningless to users.</label></li>
-<li><label><input type="checkbox" />Ensure README examples use only
-public API.</label></li>
+<li><label><input type="checkbox" checked="" />Remove internal-only bug
+IDs or notes that are meaningless to users.</label></li>
+<li><label><input type="checkbox" checked="" />Ensure README examples
+use only public API.</label></li>
 <li><label><input type="checkbox" />Ensure README examples match the
 latest Maven Central release once 2.0 is published.</label></li>
-<li><label><input type="checkbox" />Add a README idiom showing how to
-know which pattern matched, such as a closure-per-pattern
+<li><label><input type="checkbox" checked="" />Add a README idiom
+showing how to know which pattern matched, such as a closure-per-pattern
 example.</label></li>
-<li><label><input type="checkbox" />Add a README sentence explaining
-parse errors and pointing to
+<li><label><input type="checkbox" checked="" />Add a README sentence
+explaining parse errors and pointing to
 <code>RegexpParserException</code>.</label></li>
-<li><label><input type="checkbox" />Add a clear <code>1.x</code> to
-<code>2.0</code> migration section in
-<code>CHANGELOG.md</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Add clear
+<code>1.x</code> to <code>2.0</code> migration guidance to the RC
+release notes and changelog.</label></li>
 <li><label><input type="checkbox" checked="" />Publish a stable
 syntax-and-semantics reference separate from the README, including
 character/Unicode rules, match selection, exclusions, and
 examples.</label></li>
-<li><label><input type="checkbox" />Include package flattening, removed
-aliases and <code>remove()</code>, callback-offset decisions,
-build-then-use lifecycle changes, and buffer helper changes in the
-migration guide.</label></li>
-<li><label><input type="checkbox" />Add or update
+<li><label><input type="checkbox" checked="" />Include package
+flattening, removed aliases and <code>remove()</code>, callback-offset
+decisions, build-then-use lifecycle changes, and buffer helper changes
+in the migration guide.</label></li>
+<li><label><input type="checkbox" checked="" />Add or update
 <code>CONTRIBUTING.md</code> with build, test, benchmark, and PR
 expectations.</label></li>
-<li><label><input type="checkbox" />Add or update
+<li><label><input type="checkbox" checked="" />Add or update
 <code>SECURITY.md</code> with a vulnerability-reporting
 channel.</label></li>
 <li><label><input type="checkbox" />Decide whether to ship a
@@ -692,49 +715,49 @@ after release if needed.</label></li>
 </ul>
 <h2 id="javadoc-quality">Javadoc Quality</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Review every public Javadoc as
-prose, not just as generated API metadata.</label></li>
-<li><label><input type="checkbox" />Make public Javadocs precise,
-respectful, and readable.</label></li>
-<li><label><input type="checkbox" />Fix spelling, grammar, stale
-parameter names, and misleading phrasing.</label></li>
-<li><label><input type="checkbox" />Ensure Javadocs describe behavior,
-constraints, thread-safety, ownership, and lifecycle where
+<li><label><input type="checkbox" checked="" />Review every public
+Javadoc as prose, not just as generated API metadata.</label></li>
+<li><label><input type="checkbox" checked="" />Make public Javadocs
+precise, respectful, and readable.</label></li>
+<li><label><input type="checkbox" checked="" />Fix spelling, grammar,
+stale parameter names, and misleading phrasing.</label></li>
+<li><label><input type="checkbox" checked="" />Ensure Javadocs describe
+behavior, constraints, thread-safety, ownership, and lifecycle where
 relevant.</label></li>
-<li><label><input type="checkbox" />Document whether callbacks may be
-invoked concurrently.</label></li>
-<li><label><input type="checkbox" />Document matcher shutdown
+<li><label><input type="checkbox" checked="" />Document whether
+callbacks may be invoked concurrently.</label></li>
+<li><label><input type="checkbox" checked="" />Document matcher shutdown
 expectations.</label></li>
-<li><label><input type="checkbox" />Document callback offset semantics
-and substring recovery.</label></li>
-<li><label><input type="checkbox" />Document exceptions thrown by public
-methods.</label></li>
-<li><label><input type="checkbox" />Avoid exposing internal
+<li><label><input type="checkbox" checked="" />Document callback offset
+semantics and substring recovery.</label></li>
+<li><label><input type="checkbox" checked="" />Document exceptions
+thrown by public methods.</label></li>
+<li><label><input type="checkbox" checked="" />Avoid exposing internal
 implementation names in user-facing Javadocs unless
 unavoidable.</label></li>
-<li><label><input type="checkbox" />Generate and inspect local Javadocs
-before release.</label></li>
+<li><label><input type="checkbox" checked="" />Generate and inspect
+local Javadocs before release.</label></li>
 <li><label><input type="checkbox" />Inspect the published javadoc.io
 rendering after release.</label></li>
 </ul>
 <h2 id="maven-central-release-mechanics">Maven Central Release
 Mechanics</h2>
 <ul class="task-list">
-<li><label><input type="checkbox" />Confirm Central Portal namespace
-access for <code>no.rmz</code>.</label></li>
-<li><label><input type="checkbox" />Confirm
+<li><label><input type="checkbox" checked="" />Confirm Central Portal
+namespace access for <code>no.rmz</code>.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm
 <code>~/.m2/settings.xml</code> has the correct Central token server
 entry.</label></li>
-<li><label><input type="checkbox" />Confirm GPG key is available,
-current, and verified.</label></li>
-<li><label><input type="checkbox" />Run Central profile check without
-upload.</label></li>
-<li><label><input type="checkbox" />Run signed Central release-profile
-verify.</label></li>
-<li><label><input type="checkbox" />Verify detached signatures
-locally.</label></li>
-<li><label><input type="checkbox" />Run a clean downstream consumer
-smoke test after local install.</label></li>
+<li><label><input type="checkbox" checked="" />Confirm GPG key is
+available, current, and verified.</label></li>
+<li><label><input type="checkbox" checked="" />Run Central profile check
+without upload.</label></li>
+<li><label><input type="checkbox" checked="" />Run signed Central
+release-profile verify.</label></li>
+<li><label><input type="checkbox" checked="" />Verify detached
+signatures locally.</label></li>
+<li><label><input type="checkbox" checked="" />Run a clean downstream
+consumer smoke test after local install.</label></li>
 <li><label><input type="checkbox" />Upload to Central Portal with
 auto-publish disabled unless intentionally changed.</label></li>
 <li><label><input type="checkbox" />Inspect Central validation results
@@ -771,11 +794,11 @@ surface.</label></li>
 evidence with links to receipts.</label></li>
 <li><label><input type="checkbox" checked="" />State any known
 limitations honestly.</label></li>
-<li><label><input type="checkbox" />State migration notes from
-<code>1.9.x</code>, including removed aliases such as
+<li><label><input type="checkbox" checked="" />State migration notes
+from <code>1.9.x</code>, including removed aliases such as
 <code>RMatch.buffer(String)</code> if applicable.</label></li>
-<li><label><input type="checkbox" />Include a short example using the
-final 2.0 API.</label></li>
+<li><label><input type="checkbox" checked="" />Include a short example
+using the final 2.0 API.</label></li>
 </ul>
 <h2 id="github-and-issue-hygiene">GitHub and Issue Hygiene</h2>
 <ul class="task-list">
@@ -783,14 +806,14 @@ final 2.0 API.</label></li>
 before release.</label></li>
 <li><label><input type="checkbox" />Close issues that are fixed and
 verified.</label></li>
-<li><label><input type="checkbox" />Move non-blocking post-2.0 work to
-clearly labeled future issues.</label></li>
-<li><label><input type="checkbox" />Ensure known blockers are either
-fixed or explicitly accepted.</label></li>
+<li><label><input type="checkbox" checked="" />Move non-blocking
+post-2.0 work to clearly labeled future issues.</label></li>
+<li><label><input type="checkbox" checked="" />Ensure known blockers are
+either fixed or explicitly accepted.</label></li>
 <li><label><input type="checkbox" />Ensure important design notes are
 linked from relevant issues.</label></li>
-<li><label><input type="checkbox" />Ensure PRs for 2.0 blockers are
-merged or deliberately deferred.</label></li>
+<li><label><input type="checkbox" checked="" />Ensure PRs for 2.0
+blockers are merged or deliberately deferred.</label></li>
 <li><label><input type="checkbox" />Confirm <code>main</code> contains
 the intended release commit before tagging.</label></li>
 </ul>

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -4,12 +4,21 @@ This is the broad pre-2.0 checklist. It is intentionally over-inclusive: assume
 items here should be completed unless they are explicitly removed before the
 2.0 release lane starts.
 
+## RC1 Gate Status
+
+The RC1 gate is distinct from the broader final-2.0 backlog below. As of
+2026-07-13, all pre-upload RC1 gates are complete: API and syntax contracts,
+Java 21 packaging, full tests, the agogo performance regression gate, four-mode
+consumer tests, dependency hygiene, release notes, generated Javadocs, and the
+reviewed API-signature baseline. Central upload and the checks that inherently
+require a published candidate remain open.
+
 ## Release Goal
 
 - [x] State the 2.0 promise in one paragraph: what rmatch is for, what it is
   not for, and what compatibility promises start at 2.0.
-- [ ] Decide whether the last preview before 2.0 is `1.9.x`, `1.99.x`, or
-  direct `2.0.0`.
+- [x] Decide whether the last preview before 2.0 is `1.9.x`, `1.99.x`, or
+  direct `2.0.0`: proceed with `2.0.0-RC1` after `1.9.6`.
 - [x] Decide whether to cut `2.0.0-RC1` instead of using a `1.99.x` preview
   line.
 - [x] Decide the exact Java baseline for 2.0 and document it in README,
@@ -17,23 +26,23 @@ items here should be completed unless they are explicitly removed before the
 - [x] State the 2.x compatibility promise explicitly: semantic versioning
   covers the exported root API plus documented matching behavior and syntax;
   unexported implementation packages are not compatibility contracts.
-- [ ] State the deprecation and removal policy for the 2.x line, including how
+- [x] State the deprecation and removal policy for the 2.x line, including how
   much notice users receive before a public API is removed.
 - [ ] Publish at least one 2.0 release candidate and leave a short, deliberate
   feedback window for external users before the final release.
-- [ ] Confirm that `rmatch-tester` remains unpublished and project-local.
-- [ ] Confirm that the public Maven Central artifacts remain only
+- [x] Confirm that `rmatch-tester` remains unpublished and project-local.
+- [x] Confirm that the public Maven Central artifacts remain only
   `no.rmz:rmatch-parent` and `no.rmz:rmatch`.
 
 ## Public API Surface
 
-- [ ] Verify that ordinary users can do the important work using only the root
+- [x] Verify that ordinary users can do the important work using only the root
   `no.rmz.rmatch` package.
-- [ ] Verify that the published JPMS module exports only intentional public API.
-- [ ] Verify that Javadocs expose only intentional public API, not compiler,
+- [x] Verify that the published JPMS module exports only intentional public API.
+- [x] Verify that Javadocs expose only intentional public API, not compiler,
   engine, implementation, utility, node-management, test, or diagnostic
   packages.
-- [ ] Inspect the generated `-javadoc.jar`, not just local generated HTML.
+- [x] Inspect the generated `-javadoc.jar`, not just local generated HTML.
 - [ ] Inspect javadoc.io after publication and confirm it shows the intended
   surface.
 - [ ] Remove or hide public implementation classes that do not need to be
@@ -45,28 +54,28 @@ items here should be completed unless they are explicitly removed before the
 - [ ] Remove accidental public constructors and factories for internal types.
 - [ ] Remove public interfaces that are only internal wiring unless they are
   truly extension contracts.
-- [ ] Review whether `Buffer`, `Matcher`, `Action`, `RMatch`, and
+- [x] Review whether `Buffer`, `Matcher`, `Action`, `RMatch`, and
   `RegexpParserException` are the complete intended public facade.
 - [ ] Ensure public names are clear enough that examples do not need to explain
   surprising behavior.
-- [ ] Decide whether match callback offsets should become half-open
+- [x] Decide whether match callback offsets should become half-open
   `[start, end)` in 2.0, matching `String.substring`, `MatchResult`, and common
   Java convention.
 - [ ] If callback offsets remain inclusive, add a public helper so user code
   does not repeatedly write `buffer.getString(start, end + 1)`.
-- [ ] Decide whether `Matcher` should extend `AutoCloseable`.
-- [ ] If `Matcher` extends `AutoCloseable`, update README examples to use
+- [x] Decide whether `Matcher` should extend `AutoCloseable`.
+- [x] If `Matcher` extends `AutoCloseable`, update README examples to use
   try-with-resources.
-- [ ] Decide whether `shutdown()` remains part of the public lifecycle API, is
+- [x] Decide whether `shutdown()` remains part of the public lifecycle API, is
   renamed, or is complemented by `close()`.
 - [ ] Decide whether matcher worker threads should be daemon threads as a safety
   net.
-- [ ] Reserve a future-compatible API shape for flags, such as
+- [x] Reserve a future-compatible API shape for flags, such as
   `add(pattern, flags, action)`, even if not all flags ship in 2.0.
-- [ ] Decide the public representation for flags before 2.0 freezes: enum set,
+- [x] Decide the public representation for flags before 2.0 freezes: enum set,
   integer bit flags, or another explicit type.
-- [ ] Document what happens when an `Action` throws during matching.
-- [ ] Document whether one throwing action aborts the scan immediately or after
+- [x] Document what happens when an `Action` throws during matching.
+- [x] Document whether one throwing action aborts the scan immediately or after
   already-started partitions finish.
 - [x] Adopt and document a build-then-use matcher lifecycle: the first
   `match()` freezes registration and later `add()` calls fail.
@@ -91,7 +100,7 @@ items here should be completed unless they are explicitly removed before the
   remain distinct regardless of `equals()`.
 - [x] Specify that callback ordering is not guaranteed, including with a
   single-engine matcher.
-- [ ] Freeze and document remaining result semantics: longest-per-start
+- [x] Freeze and document remaining result semantics: longest-per-start
   behavior, overlapping matches, callback multiplicity across patterns, and
   duplicate pattern text with different flags.
 - [ ] Ensure parser failures identify the unsupported or malformed construct
@@ -99,18 +108,18 @@ items here should be completed unless they are explicitly removed before the
 
 ## Buffer and Input Contract
 
-- [ ] Keep the public materializing helpers named `RMatch.stringBuffer(...)`, so
+- [x] Keep the public materializing helpers named `RMatch.stringBuffer(...)`, so
   callers see that the whole input is read into a `String`.
-- [ ] Provide convenience overloads for `String`, `CharSequence`, `Path` with
+- [x] Provide convenience overloads for `String`, `CharSequence`, `Path` with
   `Charset`, `Reader`, and `InputStream` with `Charset`, if retained after API
   review.
-- [ ] Document that `Reader` and `InputStream` helpers consume but do not close
+- [x] Document that `Reader` and `InputStream` helpers consume but do not close
   the supplied object.
-- [ ] Document that current public helpers are not streaming, windowed, mmap, or
+- [x] Document that current public helpers are not streaming, windowed, mmap, or
   lazy file-backed implementations.
 - [ ] Document why the current `Buffer` contract requires finite, replayable
   input with substring lookup by offsets and independent cloned cursors.
-- [ ] Document that custom `Buffer` implementations can be passed directly to
+- [x] Document that custom `Buffer` implementations can be passed directly to
   `Matcher.match(Buffer)`.
 - [ ] State the contract a custom `Buffer` must preserve: cursor movement,
   offset-based substring lookup, comparison behavior, and independent clones.
@@ -118,8 +127,8 @@ items here should be completed unless they are explicitly removed before the
   streams in the docs.
 - [ ] Record that arbitrary streaming would need a separate bounded-window or
   maximum-lookback design and is not part of 2.0 unless intentionally added.
-- [ ] Add tests for every retained public `stringBuffer(...)` overload.
-- [ ] Add at least one small example or test showing that a user-supplied
+- [x] Add tests for every retained public `stringBuffer(...)` overload.
+- [x] Add at least one small example or test showing that a user-supplied
   `Buffer` can be matched directly.
 - [ ] Decide whether `Buffer` should stop extending `Comparable<Buffer>`.
 - [ ] If `Comparable<Buffer>` is retained, fix or document comparison behavior
@@ -140,8 +149,8 @@ items here should be completed unless they are explicitly removed before the
 
 ## Deprecated and Unused API
 
-- [ ] Search for all deprecated classes, methods, constructors, and fields.
-- [ ] Remove deprecated API that is unused or can be made unused by sensible
+- [x] Search for all deprecated classes, methods, constructors, and fields.
+- [x] Remove deprecated API that is unused or can be made unused by sensible
   internal changes.
 - [ ] If a deprecated API is still needed, remove the deprecation and document
   why it remains part of the public or internal contract.
@@ -154,14 +163,14 @@ items here should be completed unless they are explicitly removed before the
 
 ## Graph and Diagnostic Code
 
-- [ ] Review graph-printing support, including `getEdgesToPrint` and related
+- [x] Review graph-printing support, including `getEdgesToPrint` and related
   classes or methods.
 - [ ] Decide whether graph-printing belongs in core at all.
 - [ ] If graph-printing is retained, move it behind a clearly internal or
   diagnostic boundary.
 - [ ] If graph-printing can be reconstructed by inspecting core structures,
   remove dedicated graph-printing API from production surfaces.
-- [ ] Ensure graph-printing code does not leak into public Javadocs.
+- [x] Ensure graph-printing code does not leak into public Javadocs.
 
 ## Regex Syntax Contract
 
@@ -171,26 +180,26 @@ items here should be completed unless they are explicitly removed before the
 - [x] Verify line anchors `^` and `$` behavior with tests and documentation.
 - [x] Verify word boundaries `\b` and `\B` behavior with tests and
   documentation.
-- [ ] Decide whether input anchors `\A`, `\z`, or `\Z` are in or out for 2.0.
-- [ ] Decide whether pure zero-width match reporting is in or out for 2.0.
-- [ ] Decide whether `MULTILINE`, non-DOTALL `.`, scoped flags, or other mode
+- [x] Decide whether input anchors `\A`, `\z`, or `\Z` are in or out for 2.0.
+- [x] Decide whether pure zero-width match reporting is in or out for 2.0.
+- [x] Decide whether `MULTILINE`, non-DOTALL `.`, scoped flags, or other mode
   machinery is in or out for 2.0.
 - [ ] Ensure unsupported syntax fails clearly, not mysteriously.
 - [ ] Keep regex syntax examples in README aligned with the tested behavior.
 
 ## Correctness Test Gate
 
-- [ ] Run the full `rmatch` unit and semantics test suite.
-- [ ] Run the full `rmatch-tester` suite.
-- [ ] Run differential tests against `java.util.regex` for the supported syntax
+- [x] Run the full `rmatch` unit and semantics test suite.
+- [x] Run the full `rmatch-tester` suite.
+- [x] Run differential tests against `java.util.regex` for the supported syntax
   subset.
 - [ ] Expand seeded differential testing to cover multiple seeds, anchors, word
   boundaries, escapes, counted quantifiers, flags, and interactions among many
   simultaneously registered patterns.
 - [ ] Exercise hostile but valid patterns and inputs to establish practical
   bounds for compilation time, state growth, memory use, and scan completion.
-- [ ] Verify match counts before treating benchmark timings as evidence.
-- [ ] Verify edge cases for overlapping matches, longest-match behavior,
+- [x] Verify match counts before treating benchmark timings as evidence.
+- [x] Verify edge cases for overlapping matches, longest-match behavior,
   anchors, word boundaries, negated classes, counted quantifiers, and
   case-insensitive matching.
 - [ ] Confirm all skipped tests are either intentionally skipped or removed.
@@ -198,17 +207,17 @@ items here should be completed unless they are explicitly removed before the
 
 ## CI Gate
 
-- [ ] Add or verify a GitHub Actions workflow that runs the full Maven test
+- [x] Add or verify a GitHub Actions workflow that runs the full Maven test
   suite on pull requests.
 - [ ] Review Codacy critical/high findings manually; fix real command/path,
   reflection, dead-code, and release-hygiene issues, and explicitly reject
   style-only false positives.
-- [ ] Ensure CI runs more than smoke tests before 2.0.
-- [ ] Review `main-gate.yml` or its successor and ensure it does not merely
+- [x] Ensure CI runs more than smoke tests before 2.0.
+- [x] Review `main-gate.yml` or its successor and ensure it does not merely
   compile plus run a tiny smoke subset.
-- [ ] Run CI on the documented Java baseline, expected to be Java 21 unless
+- [x] Run CI on the documented Java baseline, expected to be Java 21 unless
   changed deliberately.
-- [ ] Run CI on a current newer Java version as well, such as Java 25 or 26.
+- [x] Run CI on a current newer Java version as well, such as Java 25 or 26.
 - [x] Test the packaged candidate from clean external Maven and Gradle consumer
   projects, both on the class path and as a named JPMS module; do not rely only
   on reactor tests.
@@ -218,9 +227,9 @@ items here should be completed unless they are explicitly removed before the
   branch is `main`.
 - [ ] Specifically fix, replace, or delete any stale Codacy workflow if it is
   still configured for `master` instead of `main`.
-- [ ] Add an API-compatibility gate such as japicmp or revapi after the 2.0 API
-  is frozen.
-- [ ] Configure the API-compatibility gate so accidental 2.0.x breaking changes
+- [x] Add an API-compatibility gate after the proposed 2.0 API is frozen. The
+  repository uses reviewed `javap` signatures for the exported facade.
+- [x] Configure the API-compatibility gate so accidental 2.0.x breaking changes
   fail before release.
 
 ## Performance Gate
@@ -228,14 +237,14 @@ items here should be completed unless they are explicitly removed before the
 - [x] Run the standard Docker performance regression gate on the agreed
   high-core benchmark host.
 - [x] Compare the 2.0 candidate against the latest published pre-2.0 release.
-- [ ] Compare rmatch against naive `java.util.regex` looping and RE2J looping
+- [x] Compare rmatch against naive `java.util.regex` looping and RE2J looping
   using byte-identical corpora and pattern sets.
-- [ ] Publish a small benchmark matrix rather than one favorable workload:
+- [x] Publish a small benchmark matrix rather than one favorable workload:
   include literal-heavy, structured-regex, shared-prefix, and realistic mixed
   pattern sets over more than one corpus and scale.
 - [ ] Report registration/compilation cost, steady-state scan time, peak memory,
   and single-versus-default parallel execution where each is material.
-- [ ] Show representative cells where Java regex or RE2J wins as well as where
+- [x] Show representative cells where Java regex or RE2J wins as well as where
   rmatch wins, so the performance claim states a useful crossover rather than
   implying universal superiority.
 - [x] Benchmark the packaged release-candidate JAR through the public API, not
@@ -246,11 +255,11 @@ items here should be completed unless they are explicitly removed before the
   regression is explicitly understood, justified, and accepted before release.
 - [x] Capture raw benchmark receipts, summaries, and charts in
   `docs/benchmark-receipts/...`.
-- [ ] Update the README performance chart from a recent run of the current
+- [x] Update the README performance chart from a recent run of the current
   implementation.
-- [ ] Make the chart label hardware by class, CPU model, and core/thread count,
+- [x] Make the chart label hardware by class, CPU model, and core/thread count,
   not by private machine nickname.
-- [ ] Keep the developer performance regression protocol as a separate linked
+- [x] Keep the developer performance regression protocol as a separate linked
   document, not a giant README section.
 - [x] Investigate any material performance regression before release.
 - [x] Record any material performance improvement in release notes, with
@@ -258,46 +267,46 @@ items here should be completed unless they are explicitly removed before the
 
 ## Dependency Hygiene
 
-- [ ] Run a dependency freshness pass before the 2.0 release candidate.
-- [ ] Prefer current stable versions of dependencies and plugins where tests
+- [x] Run a dependency freshness pass before the 2.0 release candidate.
+- [x] Prefer current stable versions of dependencies and plugins where tests
   and compatibility allow.
-- [ ] Avoid beta, milestone, or abandoned dependencies unless explicitly
+- [x] Avoid beta, milestone, or abandoned dependencies unless explicitly
   justified.
-- [ ] Confirm `no.rmz:rmatch` has no unintended compile/runtime dependencies.
-- [ ] Confirm test-only dependencies do not leak into compile/runtime scopes.
-- [ ] Confirm the external Aho-Corasick dependency remains removed unless a new
+- [x] Confirm `no.rmz:rmatch` has no unintended compile/runtime dependencies.
+- [x] Confirm test-only dependencies do not leak into compile/runtime scopes.
+- [x] Confirm the external Aho-Corasick dependency remains removed unless a new
   deliberate decision reintroduces it.
-- [ ] Run dependency tree checks for compile, runtime, and test scopes.
-- [ ] Run vulnerability or risk-oriented dependency checks if available in the
+- [x] Run dependency tree checks for compile, runtime, and test scopes.
+- [x] Run vulnerability or risk-oriented dependency checks if available in the
   local toolchain.
-- [ ] Record any accepted dependency risk in the release notes or release
+- [x] Record any accepted dependency risk in the release notes or release
   checklist.
 
 ## JPMS and Packaging
 
-- [ ] Verify `module-info.java` names the module `no.rmz.rmatch`.
-- [ ] Verify `jar --describe-module` reports the intended module metadata.
-- [ ] Verify no automatic-module warnings remain in the Central release profile.
-- [ ] Verify the main JAR does not contain stale classes from previous builds.
-- [ ] Run release verification from a clean checkout or after `clean`.
-- [ ] Inspect the JAR manifest.
-- [ ] Inspect embedded Maven POM properties.
-- [ ] Verify classfile major version matches the documented Java baseline.
+- [x] Verify `module-info.java` names the module `no.rmz.rmatch`.
+- [x] Verify `jar --describe-module` reports the intended module metadata.
+- [x] Verify no automatic-module warnings remain in the Central release profile.
+- [x] Verify the main JAR does not contain stale classes from previous builds.
+- [x] Run release verification from a clean checkout or after `clean`.
+- [x] Inspect the JAR manifest.
+- [x] Inspect embedded Maven POM properties.
+- [x] Verify classfile major version matches the documented Java baseline.
 - [ ] Make release artifacts reproducible where practical, including a fixed
   Maven build output timestamp, and compare clean-build hashes before release.
-- [ ] Verify source and Javadoc JARs are attached.
-- [ ] Verify generated `.asc` signatures for all published artifacts.
+- [x] Verify source and Javadoc JARs are attached.
+- [x] Verify generated `.asc` signatures for all candidate artifacts.
 
 ## Shipped Jar Hygiene
 
-- [ ] Remove direct `System.out.println` usage from library code.
-- [ ] Route retained diagnostic output through `java.util.logging` or another
+- [x] Remove direct `System.out.println` usage from library code.
+- [x] Route retained diagnostic output through `java.util.logging` or another
   deliberate logging boundary.
-- [ ] Review whether `BloomFilterMatchEngine` is live production code or a
+- [x] Review whether `BloomFilterMatchEngine` is live production code or a
   leftover experiment.
-- [ ] Remove dead experimental engines from the published artifact, or move them
+- [x] Remove dead experimental engines from the published artifact, or move them
   behind an internal/diagnostic boundary.
-- [ ] Turn Javadoc doclint back on for the public facade if feasible before
+- [x] Turn Javadoc doclint back on for the public facade if feasible before
   2.0.
 - [ ] If doclint remains disabled, document the reason and a follow-up path.
 - [ ] Extract duplicated matcher partition-count heuristics into one place, if
@@ -309,36 +318,37 @@ items here should be completed unless they are explicitly removed before the
 
 ## Documentation
 
-- [ ] Make README usable by an experienced Java developer in under five
+- [x] Make README usable by an experienced Java developer in under five
   minutes.
-- [ ] Put the dependency snippet and smallest runnable example before the long
+- [x] Put the dependency snippet and smallest runnable example before the long
   benchmark discussion so a curious developer can try rmatch immediately.
-- [ ] Include Maven Central dependency instructions near the top of README.
-- [ ] Include Gradle dependency instructions near the top of README.
-- [ ] Keep the README copy-paste example minimal, correct, and tested against a
+- [x] Include Maven Central dependency instructions near the top of README.
+- [x] Include Gradle dependency instructions near the top of README.
+- [x] Keep the README copy-paste example minimal, correct, and tested against a
   clean consumer project.
-- [ ] Explain when to use rmatch and when not to use it.
-- [ ] Explain how rmatch performance comparisons are made.
-- [ ] Link from README to the performance regression protocol.
-- [ ] Remove stale references to historical experiments that do not represent
+- [x] Explain when to use rmatch and when not to use it.
+- [x] Explain how rmatch performance comparisons are made.
+- [x] Link from README to the performance regression protocol.
+- [x] Remove stale references to historical experiments that do not represent
   the current implementation.
-- [ ] Remove internal-only bug IDs or notes that are meaningless to users.
-- [ ] Ensure README examples use only public API.
+- [x] Remove internal-only bug IDs or notes that are meaningless to users.
+- [x] Ensure README examples use only public API.
 - [ ] Ensure README examples match the latest Maven Central release once 2.0 is
   published.
-- [ ] Add a README idiom showing how to know which pattern matched, such as a
+- [x] Add a README idiom showing how to know which pattern matched, such as a
   closure-per-pattern example.
-- [ ] Add a README sentence explaining parse errors and pointing to
+- [x] Add a README sentence explaining parse errors and pointing to
   `RegexpParserException`.
-- [ ] Add a clear `1.x` to `2.0` migration section in `CHANGELOG.md`.
+- [x] Add clear `1.x` to `2.0` migration guidance to the RC release notes and
+  changelog.
 - [x] Publish a stable syntax-and-semantics reference separate from the README,
   including character/Unicode rules, match selection, exclusions, and examples.
-- [ ] Include package flattening, removed aliases and `remove()`, callback-offset
+- [x] Include package flattening, removed aliases and `remove()`, callback-offset
   decisions, build-then-use lifecycle changes, and buffer helper changes in
   the migration guide.
-- [ ] Add or update `CONTRIBUTING.md` with build, test, benchmark, and PR
+- [x] Add or update `CONTRIBUTING.md` with build, test, benchmark, and PR
   expectations.
-- [ ] Add or update `SECURITY.md` with a vulnerability-reporting channel.
+- [x] Add or update `SECURITY.md` with a vulnerability-reporting channel.
 - [ ] Decide whether to ship a zero-callback or collecting convenience for
   evaluators.
 - [ ] If a collecting convenience is added, make it thread-safe and document its
@@ -350,29 +360,29 @@ items here should be completed unless they are explicitly removed before the
 
 ## Javadoc Quality
 
-- [ ] Review every public Javadoc as prose, not just as generated API metadata.
-- [ ] Make public Javadocs precise, respectful, and readable.
-- [ ] Fix spelling, grammar, stale parameter names, and misleading phrasing.
-- [ ] Ensure Javadocs describe behavior, constraints, thread-safety, ownership,
+- [x] Review every public Javadoc as prose, not just as generated API metadata.
+- [x] Make public Javadocs precise, respectful, and readable.
+- [x] Fix spelling, grammar, stale parameter names, and misleading phrasing.
+- [x] Ensure Javadocs describe behavior, constraints, thread-safety, ownership,
   and lifecycle where relevant.
-- [ ] Document whether callbacks may be invoked concurrently.
-- [ ] Document matcher shutdown expectations.
-- [ ] Document callback offset semantics and substring recovery.
-- [ ] Document exceptions thrown by public methods.
-- [ ] Avoid exposing internal implementation names in user-facing Javadocs
+- [x] Document whether callbacks may be invoked concurrently.
+- [x] Document matcher shutdown expectations.
+- [x] Document callback offset semantics and substring recovery.
+- [x] Document exceptions thrown by public methods.
+- [x] Avoid exposing internal implementation names in user-facing Javadocs
   unless unavoidable.
-- [ ] Generate and inspect local Javadocs before release.
+- [x] Generate and inspect local Javadocs before release.
 - [ ] Inspect the published javadoc.io rendering after release.
 
 ## Maven Central Release Mechanics
 
-- [ ] Confirm Central Portal namespace access for `no.rmz`.
-- [ ] Confirm `~/.m2/settings.xml` has the correct Central token server entry.
-- [ ] Confirm GPG key is available, current, and verified.
-- [ ] Run Central profile check without upload.
-- [ ] Run signed Central release-profile verify.
-- [ ] Verify detached signatures locally.
-- [ ] Run a clean downstream consumer smoke test after local install.
+- [x] Confirm Central Portal namespace access for `no.rmz`.
+- [x] Confirm `~/.m2/settings.xml` has the correct Central token server entry.
+- [x] Confirm GPG key is available, current, and verified.
+- [x] Run Central profile check without upload.
+- [x] Run signed Central release-profile verify.
+- [x] Verify detached signatures locally.
+- [x] Run a clean downstream consumer smoke test after local install.
 - [ ] Upload to Central Portal with auto-publish disabled unless intentionally
   changed.
 - [ ] Inspect Central validation results before publishing.
@@ -396,18 +406,18 @@ items here should be completed unless they are explicitly removed before the
 - [x] State dependency surface.
 - [x] State performance evidence with links to receipts.
 - [x] State any known limitations honestly.
-- [ ] State migration notes from `1.9.x`, including removed aliases such as
+- [x] State migration notes from `1.9.x`, including removed aliases such as
   `RMatch.buffer(String)` if applicable.
-- [ ] Include a short example using the final 2.0 API.
+- [x] Include a short example using the final 2.0 API.
 
 ## GitHub and Issue Hygiene
 
 - [x] Review open GitHub issues before release.
 - [ ] Close issues that are fixed and verified.
-- [ ] Move non-blocking post-2.0 work to clearly labeled future issues.
-- [ ] Ensure known blockers are either fixed or explicitly accepted.
+- [x] Move non-blocking post-2.0 work to clearly labeled future issues.
+- [x] Ensure known blockers are either fixed or explicitly accepted.
 - [ ] Ensure important design notes are linked from relevant issues.
-- [ ] Ensure PRs for 2.0 blockers are merged or deliberately deferred.
+- [x] Ensure PRs for 2.0 blockers are merged or deliberately deferred.
 - [ ] Confirm `main` contains the intended release commit before tagging.
 
 ## Post-Release Checks

--- a/docs/api/2.0.0-RC1-public-api.txt
+++ b/docs/api/2.0.0-RC1-public-api.txt
@@ -1,0 +1,39 @@
+Compiled from "Action.java"
+public interface no.rmz.rmatch.Action {
+  public abstract void performMatch(no.rmz.rmatch.Buffer, long, long);
+}
+Compiled from "Buffer.java"
+public interface no.rmz.rmatch.Buffer {
+  public abstract boolean hasCharAt(long);
+  public abstract char charAt(long);
+  public default java.lang.String getString(long, long);
+}
+Compiled from "Matcher.java"
+public interface no.rmz.rmatch.Matcher extends java.lang.AutoCloseable {
+  public abstract void add(java.lang.String, no.rmz.rmatch.Action) throws no.rmz.rmatch.RegexpParserException;
+  public default void add(java.lang.String, java.util.Set<no.rmz.rmatch.PatternFlag>, no.rmz.rmatch.Action) throws no.rmz.rmatch.RegexpParserException;
+  public abstract void match(no.rmz.rmatch.Buffer);
+  public abstract void close();
+}
+Compiled from "PatternFlag.java"
+public final class no.rmz.rmatch.PatternFlag extends java.lang.Enum<no.rmz.rmatch.PatternFlag> {
+  public static final no.rmz.rmatch.PatternFlag CASE_INSENSITIVE;
+  public static no.rmz.rmatch.PatternFlag[] values();
+  public static no.rmz.rmatch.PatternFlag valueOf(java.lang.String);
+}
+Compiled from "RMatch.java"
+public final class no.rmz.rmatch.RMatch {
+  public static no.rmz.rmatch.Matcher newMatcher();
+  public static no.rmz.rmatch.Matcher newMatcher(int);
+  public static no.rmz.rmatch.Matcher newSingleMatcher();
+  public static no.rmz.rmatch.Buffer stringBuffer(java.lang.String);
+  public static no.rmz.rmatch.Buffer stringBuffer(java.lang.CharSequence);
+  public static no.rmz.rmatch.Buffer stringBuffer(java.nio.file.Path, java.nio.charset.Charset) throws java.io.IOException;
+  public static no.rmz.rmatch.Buffer stringBuffer(java.io.Reader) throws java.io.IOException;
+  public static no.rmz.rmatch.Buffer stringBuffer(java.io.InputStream, java.nio.charset.Charset) throws java.io.IOException;
+}
+Compiled from "RegexpParserException.java"
+public final class no.rmz.rmatch.RegexpParserException extends java.lang.Exception {
+  public no.rmz.rmatch.RegexpParserException(java.lang.String);
+  public no.rmz.rmatch.RegexpParserException(java.lang.Exception);
+}

--- a/docs/release-notes-2.0.0-RC1.md
+++ b/docs/release-notes-2.0.0-RC1.md
@@ -1,4 +1,4 @@
-# rmatch 2.0.0-RC1 release notes (draft)
+# rmatch 2.0.0-RC1 release notes
 
 `2.0.0-RC1` is the first release intended for serious evaluation by potential
 users. rmatch is a Java library for applying many regular expressions to the
@@ -50,6 +50,12 @@ The published `no.rmz:rmatch` artifact has no third-party compile-time or
 runtime dependencies. Test and benchmark libraries remain project-local, and
 `rmatch-tester` is not part of the Maven Central release lane.
 
+The final dependency-freshness pass updated JUnit to 6.1.2, the SpotBugs Maven
+plugin to 4.10.3.0, and JaCoCo to 0.8.15. Milestone and beta Maven plugins were
+deliberately excluded from the release build. With no third-party runtime
+dependencies, there is no accepted downstream runtime dependency risk to
+record for this candidate.
+
 ## Syntax and matching behavior
 
 rmatch deliberately implements a regular-language subset rather than claiming
@@ -82,8 +88,34 @@ and the four-mode consumer verification are recorded in
 
 ## RC purpose
 
-RC1 freezes the proposed 2.0 API and documented semantics for external review.
+RC1 presents the proposed 2.0 API and documented semantics for external review.
 Feedback should focus on correctness, API friction, documentation gaps,
 packaging, and workloads where the performance profile differs from the
 published evidence. A final `2.0.0` follows only after the release candidate has
 been exercised as a clean Maven, Gradle, class-path, and JPMS dependency.
+
+The candidate is not yet the final compatibility baseline. Feedback may still
+lead to source- or binary-incompatible changes in a later release candidate.
+Once `2.0.0` is final, the exported API follows semantic versioning: removals or
+incompatible changes require a new major version. Obsolete 2.x API will normally
+be deprecated in at least one minor release before removal in the next major
+release; an immediate change is reserved for severe security or correctness
+failures that cannot be handled compatibly.
+
+## Small example
+
+```java
+import no.rmz.rmatch.RMatch;
+
+try (var matcher = RMatch.newMatcher()) {
+  matcher.add("WARN|ERROR", (buffer, start, end) ->
+      System.out.println(buffer.getString(start, end)));
+  matcher.match(RMatch.stringBuffer("INFO WARN ERROR"));
+}
+```
+
+Compared with the experimental 1.x API, application types now live in
+`no.rmz.rmatch`; callbacks use half-open `[start, end)` offsets; `Matcher` is
+`AutoCloseable` and build-then-use; the experimental `remove()` operation and
+`RMatch.buffer(...)` alias are gone; and materializing input helpers are named
+`RMatch.stringBuffer(...)`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -12,21 +12,35 @@ The detailed living checklist is in
   one last public shakeout.
 - `2.0.0`: stable, fully documented release line.
 
-The proposed first candidate is `2.0.0-RC1`. It requires Java 21 or newer;
-artifacts compiled with `--release 21` cannot run on an older JVM. The draft
-release note is [release-notes-2.0.0-RC1.md](release-notes-2.0.0-RC1.md), and
+The first candidate is `2.0.0-RC1`. It requires Java 21 or newer; artifacts
+compiled with `--release 21` cannot run on an older JVM. The release note is
+[release-notes-2.0.0-RC1.md](release-notes-2.0.0-RC1.md), and
 the proposed stable language contract is
 [regex-syntax-and-semantics.md](regex-syntax-and-semantics.md).
 
 ## Public artifact lane
 
-For the `1.9.x` line, publish only:
+For the 2.0 release-candidate line, publish only:
 
 - `no.rmz:rmatch-parent`
 - `no.rmz:rmatch`
 
 Do not publish `rmatch-tester`; it is project-local benchmark and experiment
 tooling.
+
+## Compatibility policy
+
+Release candidates expose the proposed 2.0 contract for feedback and may still
+change incompatibly before the final release. Starting with `2.0.0`, semantic
+versioning covers the exported `no.rmz.rmatch` API and documented syntax and
+matching behavior. Incompatible API removal requires the next major release.
+The normal path is deprecation in at least one 2.x minor release followed by
+removal in the next major release; severe security or correctness failures may
+require a faster, explicitly documented exception.
+
+Run `make api-compat-check` before an RC or final release. The checked-in RC1
+signature is the review baseline for later candidates; it becomes the stable
+2.0 baseline only when `2.0.0` is released.
 
 ## Signing identity
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-parent</artifactId>
-    <version>1.9.7-SNAPSHOT</version>
+    <version>2.0.0-RC1</version>
 
     <packaging>pom</packaging>
 
@@ -38,8 +38,8 @@
         <maven.plugin.validation>DEFAULT</maven.plugin.validation>
         <java.version>21</java.version>
         <jmh.version>1.37</jmh.version>
-        <junit-jupiter.version>6.1.1</junit-jupiter.version>
-        <junit-platform.version>6.1.1</junit-platform.version>
+        <junit-jupiter.version>6.1.2</junit-jupiter.version>
+        <junit-platform.version>6.1.2</junit-platform.version>
         <mavenCheckstylePlugin.version>3.6.0</mavenCheckstylePlugin.version>
         <mavenAssemblyPlugin.version>3.8.0</mavenAssemblyPlugin.version>
         <mavenCompilerPlugin.version>3.15.0</mavenCompilerPlugin.version>
@@ -52,14 +52,14 @@
 
         <!-- Code quality plugins -->
         <spotless.version>3.8.0</spotless.version>
-        <spotbugs.version>4.10.2.0</spotbugs.version>
+        <spotbugs.version>4.10.3.0</spotbugs.version>
 
         <mavenSourcePlugin.version>3.4.0</mavenSourcePlugin.version>
         <mavenJavadocPlugin.version>3.12.0</mavenJavadocPlugin.version>
         <mavenGpgPlugin.version>3.2.8</mavenGpgPlugin.version>
         <centralPublishingMavenPlugin.version>0.11.0</centralPublishingMavenPlugin.version>
         <mavenSurefire.version>3.5.4</mavenSurefire.version>
-        <jacoco.version>0.8.13</jacoco.version>
+        <jacoco.version>0.8.15</jacoco.version>
         <!-- Empty default so the @{argLine} hook in surefire configs resolves
              cleanly when the coverage profile (which sets it) is not active. -->
         <argLine></argLine>

--- a/rmatch-tester/pom.xml
+++ b/rmatch-tester/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.7-SNAPSHOT</version>
+        <version>2.0.0-RC1</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch-tester</artifactId>
-    <version>1.9.7-SNAPSHOT</version>
+    <version>2.0.0-RC1</version>
     <packaging>jar</packaging>
 
     <name>rmatch-tester</name>

--- a/rmatch/pom.xml
+++ b/rmatch/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>no.rmz</groupId>
         <artifactId>rmatch-parent</artifactId>
-        <version>1.9.7-SNAPSHOT</version>
+        <version>2.0.0-RC1</version>
     </parent>
 
     <groupId>no.rmz</groupId>
     <artifactId>rmatch</artifactId>
-    <version>1.9.7-SNAPSHOT</version>
+    <version>2.0.0-RC1</version>
     <packaging>jar</packaging>
 
     <name>rmatch</name>

--- a/scripts/verify-public-api.sh
+++ b/scripts/verify-public-api.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BASELINE="$ROOT/docs/api/2.0.0-RC1-public-api.txt"
+VERSION=$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$ROOT/pom.xml" | head -n 1)
+JAR="$ROOT/rmatch/target/rmatch-$VERSION.jar"
+ACTUAL=$(mktemp "${TMPDIR:-/tmp}/rmatch-public-api.XXXXXX")
+trap 'rm -f "$ACTUAL"' EXIT
+
+if [[ ! -f "$JAR" ]]; then
+  "$ROOT/mvnw" -q -B -pl rmatch -am -DskipTests -Dspotbugs.skip=true package
+fi
+
+classes=(
+  no.rmz.rmatch.Action
+  no.rmz.rmatch.Buffer
+  no.rmz.rmatch.Matcher
+  no.rmz.rmatch.PatternFlag
+  no.rmz.rmatch.RMatch
+  no.rmz.rmatch.RegexpParserException
+)
+
+for class in "${classes[@]}"; do
+  javap -public -classpath "$JAR" "$class"
+done >"$ACTUAL"
+
+if ! diff -u "$BASELINE" "$ACTUAL"; then
+  echo "Public API differs from the reviewed 2.0.0-RC1 baseline." >&2
+  echo "Review the change; update the baseline only when it is intentional." >&2
+  exit 1
+fi
+
+echo "Public API matches $BASELINE"

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERSION=$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$ROOT/pom.xml" | head -n 1)
+MAIN_JAR="$ROOT/rmatch/target/rmatch-$VERSION.jar"
+SOURCE_JAR="$ROOT/rmatch/target/rmatch-$VERSION-sources.jar"
+JAVADOC_JAR="$ROOT/rmatch/target/rmatch-$VERSION-javadoc.jar"
+
+"$ROOT/mvnw" -q -B -pl rmatch -am -Pcentral-release -DskipTests \
+  -Dspotbugs.skip=true -Dgpg.skip=true clean verify
+
+for artifact in "$MAIN_JAR" "$SOURCE_JAR" "$JAVADOC_JAR"; do
+  test -s "$artifact" || { echo "Missing artifact: $artifact" >&2; exit 1; }
+done
+
+module=$(jar --describe-module --file "$MAIN_JAR")
+grep -q '^no.rmz.rmatch@' <<<"$module"
+grep -q '^exports no.rmz.rmatch$' <<<"$module"
+if grep -q '^exports no.rmz.rmatch\.' <<<"$module"; then
+  echo "Unexpected exported implementation package" >&2
+  exit 1
+fi
+
+packages=$(jar tf "$JAVADOC_JAR" | grep 'package-summary.html$')
+expected='no.rmz.rmatch/no/rmz/rmatch/package-summary.html'
+[[ "$packages" == "$expected" ]] || {
+  echo "Unexpected Javadoc package surface:" >&2
+  printf '%s\n' "$packages" >&2
+  exit 1
+}
+
+jar tf "$MAIN_JAR" | grep -q '^META-INF/MANIFEST.MF$'
+jar tf "$MAIN_JAR" | grep -q '^META-INF/maven/no.rmz/rmatch/pom.properties$'
+major=$(javap -verbose -classpath "$MAIN_JAR" no.rmz.rmatch.RMatch | sed -n 's/.*major version: //p')
+[[ "$major" == 65 ]] || { echo "Expected Java 21 class major 65, got $major" >&2; exit 1; }
+
+echo "Release artifacts PASS for no.rmz:rmatch:$VERSION"
+printf '%s\n' "$module"
+echo "Classfile major: $major (Java 21)"


### PR DESCRIPTION
## Summary
- prepare version and user-facing notes for 2.0.0-RC1
- reconcile the broad 2.0 checklist with the completed RC1 gates
- add reviewed public-API and release-artifact verification
- refresh stable test/build dependencies

## Verification
- full Maven reactor verify
- strict Central-profile Javadocs and artifact inspection
- signed Central-profile verify; all five detached signatures verified
- public API signature check
- Maven, Gradle, classpath, and JPMS consumers on agogo
- existing eight-cell agogo performance gate against 1.9.6 remains within 3%

Central remains configured with `autoPublish=false`; deployment will be inspected before publication.