### PR TITLE
Record validated 2.0.0-RC1 deployment

### DIFF
--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -758,10 +758,13 @@ release-profile verify.</label></li>
 signatures locally.</label></li>
 <li><label><input type="checkbox" checked="" />Run a clean downstream
 consumer smoke test after local install.</label></li>
-<li><label><input type="checkbox" />Upload to Central Portal with
-auto-publish disabled unless intentionally changed.</label></li>
-<li><label><input type="checkbox" />Inspect Central validation results
-before publishing.</label></li>
+<li><label><input type="checkbox" checked="" />Upload to Central Portal
+with auto-publish disabled unless intentionally changed.</label></li>
+<li><label><input type="checkbox" checked="" />Inspect Central
+validation results before publishing. Deployment
+<code>7de1d87f-d4b5-4c25-bd35-f0119c1fc505</code> reached
+<code>VALIDATED</code> on 2026-07-13 and remains pending manual
+publication.</label></li>
 <li><label><input type="checkbox" />Publish the validated
 deployment.</label></li>
 <li><label><input type="checkbox" />Confirm Maven Central artifact

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -383,9 +383,11 @@ require a published candidate remain open.
 - [x] Run signed Central release-profile verify.
 - [x] Verify detached signatures locally.
 - [x] Run a clean downstream consumer smoke test after local install.
-- [ ] Upload to Central Portal with auto-publish disabled unless intentionally
+- [x] Upload to Central Portal with auto-publish disabled unless intentionally
   changed.
-- [ ] Inspect Central validation results before publishing.
+- [x] Inspect Central validation results before publishing. Deployment
+  `7de1d87f-d4b5-4c25-bd35-f0119c1fc505` reached `VALIDATED` on 2026-07-13
+  and remains pending manual publication.
 - [ ] Publish the validated deployment.
 - [ ] Confirm Maven Central artifact availability by direct HTTP checks.
 - [ ] Create a GitHub Release for `2.0.0` from the verified tag, with concise

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -650,6 +650,24 @@ the rest of the release work here as it becomes explicit.
   2026-07-07: `CHANGELOG.md` records Maven Central publication date, coordinate
   `no.rmz:rmatch:1.9.1`, tag `rmatch-1.9.1`, and release commit `5ee41857`.
 
+## 2.0.0-RC1 Release Run
+
+- [x] Merge release preparation PR #305 after all Java 21/25, security,
+  coverage, static-analysis, smoke, and performance-canary checks passed.
+  Release merge commit: `d97df431`.
+- [x] Verify the signed Central profile locally and validate all five detached
+  signatures.
+- [x] Verify Maven, Gradle, direct classpath, and named JPMS consumers against
+  the exact candidate commit on the high-core test host.
+- [x] Upload with Central plugin `autoPublish=false` and
+  `waitUntil=VALIDATED`.
+- [x] Confirm Central validation. Deployment
+  `7de1d87f-d4b5-4c25-bd35-f0119c1fc505` reached `VALIDATED` on 2026-07-13
+  and explicitly requires manual publication.
+- [ ] Inspect and manually publish the validated Central deployment.
+- [ ] After publication, verify Central availability, javadoc.io, clean remote
+  consumers, release tag, GitHub Release, README badges, and next snapshot.
+
 ## Known Follow-Up Release Work
 
 - [ ] Expand public API documentation for the callback coordinate convention.


### PR DESCRIPTION
Records the validated, manually gated Central deployment for 2.0.0-RC1. No publication or tag has been performed.

Deployment: `7de1d87f-d4b5-4c25-bd35-f0119c1fc505`
State: `VALIDATED`
Auto-publish: disabled