### PR TITLE
Add GitHub release steps to release checklist

### DIFF
--- a/docs/2.0-release-checklist.html
+++ b/docs/2.0-release-checklist.html
@@ -769,15 +769,19 @@ publication.</label></li>
 deployment.</label></li>
 <li><label><input type="checkbox" />Confirm Maven Central artifact
 availability by direct HTTP checks.</label></li>
-<li><label><input type="checkbox" />Create a GitHub Release for
-<code>2.0.0</code> from the verified tag, with concise release notes and
-direct links to Maven Central, Javadocs, migration notes, and benchmark
-receipts.</label></li>
+<li><label><input type="checkbox" />For every release candidate and
+final release, create and push an annotated
+<code>rmatch-&lt;version&gt;</code> tag pointing to the exact commit
+used to build the published Central artifacts.</label></li>
+<li><label><input type="checkbox" />For every release candidate and
+final release, create a GitHub Release from the verified tag, mark
+candidates as prereleases, and include concise notes with links to Maven
+Central, Javadocs, migration notes, and benchmark receipts.</label></li>
 <li><label><input type="checkbox" />Run a clean-repository consumer
 smoke test against the published Central artifact.</label></li>
-<li><label><input type="checkbox" />Create and push the annotated
-<code>rmatch-2.0.0</code> tag only after Central validation/publication
-is confirmed.</label></li>
+<li><label><input type="checkbox" />Verify the final
+<code>rmatch-2.0.0</code> annotated tag points to the exact Central
+artifact commit after publication is confirmed.</label></li>
 <li><label><input type="checkbox" />Bump mainline to the next snapshot
 after the 2.0 release.</label></li>
 </ul>

--- a/docs/2.0-release-checklist.md
+++ b/docs/2.0-release-checklist.md
@@ -390,13 +390,17 @@ require a published candidate remain open.
   and remains pending manual publication.
 - [ ] Publish the validated deployment.
 - [ ] Confirm Maven Central artifact availability by direct HTTP checks.
-- [ ] Create a GitHub Release for `2.0.0` from the verified tag, with concise
-  release notes and direct links to Maven Central, Javadocs, migration notes,
-  and benchmark receipts.
+- [ ] For every release candidate and final release, create and push an
+  annotated `rmatch-<version>` tag pointing to the exact commit used to build
+  the published Central artifacts.
+- [ ] For every release candidate and final release, create a GitHub Release
+  from the verified tag, mark candidates as prereleases, and include concise
+  notes with links to Maven Central, Javadocs, migration notes, and benchmark
+  receipts.
 - [ ] Run a clean-repository consumer smoke test against the published Central
   artifact.
-- [ ] Create and push the annotated `rmatch-2.0.0` tag only after Central
-  validation/publication is confirmed.
+- [ ] Verify the final `rmatch-2.0.0` annotated tag points to the exact Central
+  artifact commit after publication is confirmed.
 - [ ] Bump mainline to the next snapshot after the 2.0 release.
 
 ## Release Notes

--- a/docs/maven-central-release-checklist.md
+++ b/docs/maven-central-release-checklist.md
@@ -664,9 +664,15 @@ the rest of the release work here as it becomes explicit.
 - [x] Confirm Central validation. Deployment
   `7de1d87f-d4b5-4c25-bd35-f0119c1fc505` reached `VALIDATED` on 2026-07-13
   and explicitly requires manual publication.
-- [ ] Inspect and manually publish the validated Central deployment.
+- [x] Inspect and manually publish the validated Central deployment. Direct
+  Maven Central and javadoc.io checks confirmed `2.0.0-RC1` is public on
+  2026-07-13.
+- [x] Create and push annotated tag `rmatch-2.0.0-RC1`; its peeled target is
+  the Central artifact commit `d97df431`.
+- [x] Create the GitHub Release from that tag and mark it as a prerelease:
+  <https://github.com/la3lma/rmatch/releases/tag/rmatch-2.0.0-RC1>.
 - [ ] After publication, verify Central availability, javadoc.io, clean remote
-  consumers, release tag, GitHub Release, README badges, and next snapshot.
+  consumers, README badges, and next snapshot.
 
 ## Known Follow-Up Release Work
 


### PR DESCRIPTION
Makes annotated tagging and GitHub Release creation explicit, independent steps for every release candidate and final release. Also records the completed RC1 tag and prerelease.